### PR TITLE
Parallelize bootan

### DIFF
--- a/docsrc/source/installation.rst
+++ b/docsrc/source/installation.rst
@@ -38,6 +38,7 @@ DeerLab will install the following packages:
 	* `numpy <https://numpy.org/>`_ -  Base N-dimensional array package 
 	* `scipy <https://www.scipy.org/>`_ - Fundamental library for scientific computing
 	* `numdifftools <https://numdifftools.readthedocs.io/en/latest/index.html>`_ - Tools to solve automatic numerical differentiation problems in one or more variables.
+	* `joblib <https://joblib.readthedocs.io/en/latest/>`_ - Library lightweight pipelining and parallelization.
 
 The installed numerical packages (numpy, scipy, cvxopt) are linked against different BLAS libraries depending on the OS:
 

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,10 @@ import subprocess
 
 # Custom OS-specific installation script
 def install_dependencies():
+#-----------------------------------------------------------------------
     subprocess.run(['pip','install','memoization'],check=True)
     subprocess.run(['pip','install','matplotlib'],check=True)
+
     # Dependencies with OS-specific BLAS
     if platform.system() == 'Windows':  
         # Install Numpy,SciPy, CVXopt linked to MKL
@@ -20,21 +22,28 @@ def install_dependencies():
         subprocess.run(['pip','install','numpy'],check=True)
         subprocess.run(['pip','install','scipy'],check=True)
         subprocess.run(['pip','install','cvxopt'],check=True)
-    subprocess.run(['pip','install','numdifftools'],check=True)
 
+    subprocess.run(['pip','install','numdifftools'],check=True)
+    subprocess.run(['pip','install','tqdm'],check=True)
+    subprocess.run(['pip','install','joblib'],check=True)
+#-----------------------------------------------------------------------    
 
 class install_routine(install):
+#-----------------------------------------------------------------------
     """Customized setuptools install command"""
     def run(self):
         install.run(self)
         install_dependencies()
+#-----------------------------------------------------------------------
 
 class develop_routine(develop):
+#-----------------------------------------------------------------------
     """Customized setuptools install command"""
     def run(self):
         develop.run(self)
         install_dependencies()
         subprocess.run(['pip','install','pytest'],check=True) # Install only on development version
+#-----------------------------------------------------------------------
 
 
 setup(

--- a/test/test_bootan.py
+++ b/test/test_bootan.py
@@ -117,4 +117,28 @@ def test_multiple_datasets():
 
     assert all(abs(paruq.mean - fit.param) < 1e-2)
 # ======================================================================
-test_multiple_datasets()
+
+
+def test_parallelization():
+# ======================================================================
+    "Check that bootan can run with multiple cores"
+
+    t = np.linspace(0,5,200)
+    r = np.linspace(2,6,300)
+    P = dd_gauss(r,[4, 0.8])
+    K = dipolarkernel(t,r)
+    Vexp = K@P + whitegaussnoise(t,0.01)
+
+    par0 = [3, 0.5]
+    Vmodel = lambda par: K@dd_gauss(r,par)
+    fit = fitparamodel(Vexp,Vmodel,par0)
+    Vfit = Vmodel(fit.param)
+
+    def bootfcn(V):
+        fit = fitparamodel(V,Vmodel,par0)
+        return fit.param
+
+    paruq = bootan(bootfcn,Vexp,Vfit,10,cores=-1)
+
+    assert all(abs(paruq.mean - fit.param) < 1e-2)
+# ======================================================================


### PR DESCRIPTION
As requested in #23, added parallel computing functionality to `bootan` using the Joblib library.
Improved the verbose system and refactoring to optimize parallel computation.