### PR TITLE
Pathways interface simplification

### DIFF
--- a/deerlab/dipolarbackground.py
+++ b/deerlab/dipolarbackground.py
@@ -6,7 +6,7 @@
 import numpy as np
 import types
 
-def dipolarbackground(t, pathinfo, Bmodel, renormalize=True):
+def dipolarbackground(t, pathinfo, Bmodel, renormalize=True, renormpaths=True):
     r""" Constructs background decay functions according to the multi-pathway model.
     
     Parameters
@@ -20,7 +20,11 @@ def dipolarbackground(t, pathinfo, Bmodel, renormalize=True):
         If a single value is specified, it is interpreted as the 4-pulse DEER pathway amplitude (modulation depth).  
     Bmodel : callable
         Background basis function. A callable function accepting a time-axis array as first input and a pathway amplitude as a second, i.e. ``B = lambda t,lam: bg_model(t,par,lam)``
-     
+    renormalize : boolean, optional
+        Re-normalization of the multi-pathway background to ensure the equality ``B(t=0)==1`` is satisfied. Enabled by default.
+    renormpaths: boolean, optional
+        Normalization of the pathway amplitudes such that ``Lam0 + lam1 + ... + lamN = 1``. Enabled by default.  
+
     Returns
     -------
     B : ndarray
@@ -84,10 +88,11 @@ def dipolarbackground(t, pathinfo, Bmodel, renormalize=True):
             raise KeyError('The pathway #{} must be a list of two or three elements [lam, T0] or [lam, T0, n]'.format(i))
 
     # Normalize the pathway amplitudes to unity
-    lamsum = Lambda0 + sum([path[0] for path in pathinfo])
-    Lambda0 /= lamsum
-    for i in range(len(pathinfo)):
-        pathinfo[i][0] /= lamsum 
+    if renormpaths:
+        lamsum = Lambda0 + sum([path[0] for path in pathinfo])
+        Lambda0 /= lamsum
+        for i in range(len(pathinfo)):
+            pathinfo[i][0] /= lamsum 
 
     # Construction of multi-pathway background function 
     #-------------------------------------------------------------------------------

--- a/deerlab/dipolarbackground.py
+++ b/deerlab/dipolarbackground.py
@@ -67,9 +67,6 @@ def dipolarbackground(t, pathinfo, Bmodel, renormalize=True):
         lam = pathinfo[0]
         pathinfo = [[1-lam], [lam, 0]]
 
-    # Normalize the pathway amplitudes to unity
-    #pathinfo[:,0] = pathinfo[:,0]/sum(pathinfo[:,0])
-
     pathinfo = [np.atleast_1d(path) for path in pathinfo]
     
     # Get unmodulated pathways    
@@ -85,6 +82,12 @@ def dipolarbackground(t, pathinfo, Bmodel, renormalize=True):
         elif len(path) != 3:
             # Otherwise paths are not correctly defined
             raise KeyError('The pathway #{} must be a list of two or three elements [lam, T0] or [lam, T0, n]'.format(i))
+
+    # Normalize the pathway amplitudes to unity
+    lamsum = Lambda0 + sum([path[0] for path in pathinfo])
+    Lambda0 /= lamsum
+    for i in range(len(pathinfo)):
+        pathinfo[i][0] /= lamsum 
 
     # Construction of multi-pathway background function 
     #-------------------------------------------------------------------------------

--- a/deerlab/dipolarbackground.py
+++ b/deerlab/dipolarbackground.py
@@ -14,10 +14,11 @@ def dipolarbackground(t,pathinfo,Bmodel,renormalize = True,overtonecoeff = 1):
     ----------
     t : array_like
         Time axis, in microseconds.
-    pathinfo : array_like with shape (p,2) or (p,3)
-        Array of pathway amplitudes (lambda), refocusing points (T0), and harmonics (n) 
-        for multiple (p) dipolar pathways. Each row contains ``[lambda T0 n]`` or ``[lambda T0]`` 
-        for one pathway. If n is not given it is assumed to be 1. For a pathway with unmodulated contribution, set the refocusing time to ``numpy.nan``.
+    pathinfo : list of lists or scalar
+        List of pathways. Each pathway is defined as a list of the pathway's amplitude (lambda), refocusing time (T0), 
+        and harmonic (n), i.e. ``[lambda, T0, n]`` or ``[lambda, T0]`` for one pathway. If n is not given it is assumed to be 1. 
+        For a pathway with unmodulated contribution, only the amplitude must be specified, i.e. ``[Lambda0]``.
+        If a single value is specified, it is interpreted as the 4-pulse DEER pathway amplitude (modulation depth).  
     Bmodel : callable
         Background basis function. A callable function accepting a time-axis array as first input and a pathway amplitude as a second, i.e. ``B = lambda t,lam: bg_model(t,par,lam)``
      

--- a/deerlab/dipolarbackground.py
+++ b/deerlab/dipolarbackground.py
@@ -51,13 +51,14 @@ def dipolarbackground(t, pathinfo, Bmodel, renormalize=True, renormpaths=True):
         conc = 200   # spin concentration (uM)
 
         pathinfo = []
-        pathinfo.append([1-lam]) # unmodulated part, gives offset
-        pathinfo.append([lam, 0]) # main modulation, refocusing at time zero
+        path0 = [1-lam]             # unmodulated part, gives offset
+        path1 = [lam, 0]            # main modulation, refocusing at time zero
+        pathways = [path0, path1]
 
         def Bmodel(t,lam):
             return dl.bg_hom3d(t,conc,lam)
 
-        B = dl.dipolarbackground(t,pathinfo,Bmodel)
+        B = dl.dipolarbackground(t,pathways,Bmodel)
     """
 
     # Ensure that all inputs are numpy arrays

--- a/deerlab/dipolarbackground.py
+++ b/deerlab/dipolarbackground.py
@@ -6,14 +6,14 @@
 import numpy as np
 import types
 
-def dipolarbackground(t, pathinfo, Bmodel, renormalize=True, renormpaths=True):
+def dipolarbackground(t, pathways, Bmodel, renormalize=True, renormpaths=True):
     r""" Constructs background decay functions according to the multi-pathway model.
     
     Parameters
     ----------
     t : array_like
         Time axis, in microseconds.
-    pathinfo : list of lists or scalar
+    pathways : list of lists or scalar
         List of pathways. Each pathway is defined as a list of the pathway's amplitude (lambda), refocusing time (T0), 
         and harmonic (n), i.e. ``[lambda, T0, n]`` or ``[lambda, T0]`` for one pathway. If n is not given it is assumed to be 1. 
         For a pathway with unmodulated contribution, only the amplitude must be specified, i.e. ``[Lambda0]``.
@@ -37,7 +37,7 @@ def dipolarbackground(t, pathinfo, Bmodel, renormalize=True, renormpaths=True):
 
     Notes
     -----
-    Computes the multipathway background ``B`` for the time axis ``t`` corresponding to the dipolar pathways specified in ``pathinfo``. The total background is computed from the basis background function model specified in ``Bmodel``. For a multi-pathway DEER signal (e.g, 4-pulse DEER with 2+1 contribution; 5-pulse DEER with 4-pulse DEER residual signal, and more complicated experiments), ``pathinfo`` is a 2D-array that contains a list of modulation depths (amplitudes), refocusing times (in microseconds), and optional harmonics for all modulated pathway signals
+    Computes the multipathway background ``B`` for the time axis ``t`` corresponding to the dipolar pathways specified in ``pathways``. The total background is computed from the basis background function model specified in ``Bmodel``. For a multi-pathway DEER signal (e.g, 4-pulse DEER with 2+1 contribution; 5-pulse DEER with 4-pulse DEER residual signal, and more complicated experiments), ``pathways`` is a 2D-array that contains a list of modulation depths (amplitudes), refocusing times (in microseconds), and optional harmonics for all modulated pathway signals
 
     Examples
     --------
@@ -50,7 +50,7 @@ def dipolarbackground(t, pathinfo, Bmodel, renormalize=True, renormpaths=True):
         lam = 0.4 # modulation depth main signal
         conc = 200   # spin concentration (uM)
 
-        pathinfo = []
+        pathways = []
         path0 = [1-lam]             # unmodulated part, gives offset
         path1 = [lam, 0]            # main modulation, refocusing at time zero
         pathways = [path0, path1]
@@ -67,39 +67,39 @@ def dipolarbackground(t, pathinfo, Bmodel, renormalize=True, renormpaths=True):
     if type(Bmodel) is not types.LambdaType:
         raise TypeError('For a model with multiple modulated pathways, B must be a function handle of the type: @(t,lambda) bg_model(t,par,lambda)')
 
-    if not isinstance(pathinfo,list): pathinfo = [pathinfo] 
-    if len(pathinfo) == 1:
-        lam = pathinfo[0]
-        pathinfo = [[1-lam], [lam, 0]]
+    if not isinstance(pathways,list): pathways = [pathways] 
+    if len(pathways) == 1:
+        lam = pathways[0]
+        pathways = [[1-lam], [lam, 0]]
 
-    pathinfo = [np.atleast_1d(path) for path in pathinfo]
+    pathways = [np.atleast_1d(path) for path in pathways]
     
     # Get unmodulated pathways    
-    unmodulated = [pathinfo.pop(i) for i,path in enumerate(pathinfo) if len(path)==1]
+    unmodulated = [pathways.pop(i) for i,path in enumerate(pathways) if len(path)==1]
     # Combine all unmodulated contributions
     Lambda0 = sum(np.concatenate([path for path in unmodulated]))
 
     # Check structure of pathways
-    for i,path in enumerate(pathinfo):
+    for i,path in enumerate(pathways):
         if len(path) == 2:
             # If harmonic is not defined, append default n=1
-            pathinfo[i] = np.append(path,1) 
+            pathways[i] = np.append(path,1) 
         elif len(path) != 3:
             # Otherwise paths are not correctly defined
             raise KeyError('The pathway #{} must be a list of two or three elements [lam, T0] or [lam, T0, n]'.format(i))
 
     # Normalize the pathway amplitudes to unity
     if renormpaths:
-        lamsum = Lambda0 + sum([path[0] for path in pathinfo])
+        lamsum = Lambda0 + sum([path[0] for path in pathways])
         Lambda0 /= lamsum
-        for i in range(len(pathinfo)):
-            pathinfo[i][0] /= lamsum 
+        for i in range(len(pathways)):
+            pathways[i][0] /= lamsum 
 
     # Construction of multi-pathway background function 
     #-------------------------------------------------------------------------------
     Bnorm = 1
     B = 1
-    for pathway in pathinfo:        
+    for pathway in pathways:        
         n,T0,lam = pathway
         B = B*Bmodel(n*(t-T0),lam)
         Bnorm = Bnorm*Bmodel(-T0*n,lam)

--- a/deerlab/dipolarbackground.py
+++ b/deerlab/dipolarbackground.py
@@ -1,4 +1,3 @@
-
 # dipolarbackground.py - Multipathway background generator 
 # --------------------------------------------------------
  # This file is a part of DeerLab. License is MIT (see LICENSE.md).
@@ -7,7 +6,7 @@
 import numpy as np
 import types
 
-def dipolarbackground(t,pathinfo,Bmodel,renormalize = True,overtonecoeff = 1):
+def dipolarbackground(t, pathinfo, Bmodel, renormalize=True):
     r""" Constructs background decay functions according to the multi-pathway model.
     
     Parameters
@@ -31,8 +30,6 @@ def dipolarbackground(t,pathinfo,Bmodel,renormalize = True,overtonecoeff = 1):
     ----------------
     renormalize : boolean
         The multi-pathway background does not necessarily satisfy ``V(0) == 1``. This option enables/disables a re-normalization of the background function to ensure that equality is satisfied, by default it is enabled.
-    overtonecoeff : array_like
-        Array containing the overtone coefficients for RIDME experiments. 
 
     Notes
     -----
@@ -61,7 +58,6 @@ def dipolarbackground(t,pathinfo,Bmodel,renormalize = True,overtonecoeff = 1):
 
     # Ensure that all inputs are numpy arrays
     t = np.atleast_1d(t)
-    overtonecoeff = np.atleast_1d(overtonecoeff)
 
     if type(Bmodel) is not types.LambdaType:
         raise TypeError('For a model with multiple modulated pathways, B must be a function handle of the type: @(t,lambda) bg_model(t,par,lambda)')

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -23,7 +23,7 @@ h = 6.62607015e-34 # Planck constant, J/Hz
 def w0(g):
     return (mu0/2)*muB**2*g[0]*g[1]/h*1e21 # Hz m^3 -> MHz nm^3 -> Mrad s^-1 nm^3
 
-def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = inf, g = [ge, ge], 
+def dipolarkernel(t, r, pathways = 1, B = 1, method = 'fresnel', excbandwidth = inf, g = [ge, ge], 
                   integralop = True, nKnots = 5001, renormalize = True, renormpaths=True, clearcache = False):
 #===================================================================================================
     r"""Compute the dipolar kernel operator which enables the linear transformation from
@@ -35,7 +35,7 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
         Dipolar time axis, in microseconds.
     r : array_like
         Distance axis, in nanometers.
-    pathinfo : list of lists or scalar
+    pathways : list of lists or scalar
         List of pathways. Each pathway is defined as a list of the pathway's amplitude (lambda), refocusing time (T0), 
         and harmonic (n), i.e. ``[lambda, T0, n]`` or ``[lambda, T0]`` for one pathway. If n is not given it is assumed to be 1. 
         For a pathway with unmodulated contribution, only the amplitude must be specified, i.e. ``[Lambda0]``.
@@ -74,7 +74,7 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
 
     Notes
     -----
-    For a multi-pathway DEER [1]_ signal (e.g, 4-pulse DEER with 2+1 contribution 5-pulse DEER with 4-pulse DEER residual signal, and more complicated experiments), ``pathinfo`` contains a list of modulation depths (amplitudes) and refocusing times (in microseconds).
+    For a multi-pathway DEER [1]_ signal (e.g, 4-pulse DEER with 2+1 contribution 5-pulse DEER with 4-pulse DEER residual signal, and more complicated experiments), ``pathways`` contains a list of modulation depths (amplitudes) and refocusing times (in microseconds).
     The background function specified as ''B'' is used as basis function, and the actual multipathway background included into the kernel is compued using :ref:`dipolarbackground`. The background in included in the dipolar kernel definition [2]_. 
     Optionally, the harmonic (1 = fundamental, 2 = first overtone, etc.) can be given as a third value in each row. This can be useful for modeling RIDME signals [3]_. If not given, the harmonic is 1 for all pathways. 
 
@@ -86,7 +86,7 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
         lam = 0.4  # modulation depth main signal
         pathways = [[1-lam], [lam, 0]]
         
-        K = dl.dipolarkernel(t,r,pathinfo)
+        K = dl.dipolarkernel(t,r,pathways)
 
 
     A shorthand input syntax equivalent to this input::
@@ -143,12 +143,12 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
     if np.any(r<=0):
         raise ValueError("All elements in r must be nonnegative and nonzero.")
 
-    if not isinstance(pathinfo,list): pathinfo = [pathinfo] 
-    if len(pathinfo) == 1:
-        lam = pathinfo[0]
-        pathinfo = [[1-lam], [lam, 0]]
+    if not isinstance(pathways,list): pathways = [pathways] 
+    if len(pathways) == 1:
+        lam = pathways[0]
+        pathways = [[1-lam], [lam, 0]]
 
-    paths = [np.atleast_1d(path) for path in pathinfo]
+    paths = [np.atleast_1d(path) for path in pathways]
 
     # Get unmodulated pathways    
     unmodulated = [paths.pop(i) for i,path in enumerate(paths) if len(path)==1]
@@ -190,7 +190,7 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
 
     # Multiply by background
     if ismodelB:
-        B = dipolarbackground(t,pathinfo,B)
+        B = dipolarbackground(t,pathways,B)
     K = K*B[:,np.newaxis]
 
     # Include delta-r factor for integration

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -24,7 +24,7 @@ def w0(g):
     return (mu0/2)*muB**2*g[0]*g[1]/h*1e21 # Hz m^3 -> MHz nm^3 -> Mrad s^-1 nm^3
 
 def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = inf, g = [ge, ge], 
-                  integralop = True, nKnots = 5001, renormalize = True, clearcache = False):
+                  integralop = True, nKnots = 5001, renormalize = True, renormpaths=True, clearcache = False):
 #===================================================================================================
     r"""Compute the dipolar kernel operator which enables the linear transformation from
     distance-domain to time-domain data. 
@@ -61,9 +61,11 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
     nKnots : scalar, optional
         Number of knots for the grid of powder orientations to be used in the 'grid' kernel calculation method.
     renormalize : boolean, optional
-        Re-normalization of multi-pathway kernels to ensure the equality ``K(t=0,r)==1`` is satisfied. Default is True.
+        Re-normalization of multi-pathway kernels to ensure the equality ``K(t=0,r)==1`` is satisfied. Enabled by default.
+    renormpaths: boolean, optional
+        Normalization of the pathway amplitudes such that ``Lam0 + lam1 + ... + lamN = 1``. Enabled by default. 
     clearcache : boolean, optional
-        Clear the cached dipolar kernels at the beginning of the function. Default is False.
+        Clear the cached dipolar kernels at the beginning of the function. Disabled by default.
 
     Returns
     --------
@@ -164,10 +166,11 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
             raise KeyError('The pathway #{} must be a list of two or three elements [lam, T0] or [lam, T0, n]'.format(i))
 
     # Normalize the pathway amplitudes to unity
-    lamsum = Lambda0 + sum([path[0] for path in paths])
-    Lambda0 /= lamsum
-    for i in range(len(paths)):
-        paths[i][0] /= lamsum 
+    if renormpaths:
+        lamsum = Lambda0 + sum([path[0] for path in paths])
+        Lambda0 /= lamsum
+        for i in range(len(paths)):
+            paths[i][0] /= lamsum 
 
     # Define kernel matrix auxiliary function
     kernelmatrix = lambda t: calckernelmatrix(t,r,method,excbandwidth,nKnots,g)

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -84,9 +84,7 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
     To specify the standard model for 4-pulse DEER with an unmodulated offset and a single dipolar pathway that refocuses at time 0, use::
     
         lam = 0.4  # modulation depth main signal
-        pathinfo = []
-        pathinfo.append([1-lam])      # unmodulated part, gives offset
-        pathinfo.append([lam, 0])     # main modulation, refocusing at time zero
+        pathways = [[1-lam], [lam, 0]]
         
         K = dl.dipolarkernel(t,r,pathinfo)
 
@@ -103,12 +101,13 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
         lam = 0.4                      # modulation depth main signal
         lam21 = 0.1                    # modulation depth 2+1 contribution
         tau2 = 4                       # refocusing time (us) of 2+1 contribution
-        pathinfo = []
-        pathinfo.append([Lam0])           # unmodulated part, gives offset
-        pathinfo.append([lam1,   0  ])    # main modulation, refocusing at time zero
-        pathinfo.append([lam2,  tau2])    # 2+1 modulation, refocusing at time tau2 
+
+        path0 = Lam0            # unmodulated pathway
+        path1 = [lam1, 0]       # main dipolar pathway, refocusing at time zero
+        path1 = [lam2, tau2]    # 2+1 dipolar pathway, refocusing at time tau2
+        pathways = [path0, path1, path2]  
         
-        K = dl.dipolarkernel(t,r,pathinfo)
+        K = dl.dipolarkernel(t,r,pathways)
 
 
     References

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -35,10 +35,11 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
         Dipolar time axis, in microseconds.
     r : array_like
         Distance axis, in nanometers.
-    pathinfo : array_like with shape (p,2) or (p,3)
-        Array of pathway amplitudes (lambda), refocusing points (T0), and harmonics (n) 
-        for multiple (p) dipolar pathways. Each row contains ``[lambda T0 n]`` or ``[lambda T0]`` 
-        for one pathway. If n is not given it is assumed to be 1. For a pathway with unmodulated contribution, set the refocusing time to ``numpy.nan``.
+    pathinfo : list of lists or scalar
+        List of pathways. Each pathway is defined as a list of the pathway's amplitude (lambda), refocusing time (T0), 
+        and harmonic (n), i.e. ``[lambda, T0, n]`` or ``[lambda, T0]`` for one pathway. If n is not given it is assumed to be 1. 
+        For a pathway with unmodulated contribution, only the amplitude must be specified, i.e. ``[Lambda0]``.
+        If a single value is specified, it is interpreted as the 4-pulse DEER pathway amplitude (modulation depth).  
     B : callable or array_like
         For a single-pathway model, the numerical background decay can be passed as an array. 
         For multiple pathways, a callable function must be passed, accepting a time-axis array as first input and a pathway amplitude as a second, i.e. ``B = lambda t,lam: bg_model(t,par,lam)``
@@ -81,8 +82,10 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
     To specify the standard model for 4-pulse DEER with an unmodulated offset and a single dipolar pathway that refocuses at time 0, use::
     
         lam = 0.4  # modulation depth main signal
-        pathinfo = [[1-lam, nan], [lam, 0]]
-
+        pathinfo = []
+        pathinfo.append([1-lam])      # unmodulated part, gives offset
+        pathinfo.append([lam, 0])     # main modulation, refocusing at time zero
+        
         K = dl.dipolarkernel(t,r,pathinfo)
 
 
@@ -97,22 +100,22 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
         Lam0 = 0.5                     # unmodulated part
         lam = 0.4                      # modulation depth main signal
         lam21 = 0.1                    # modulation depth 2+1 contribution
-        tau2 = 4                       # refocusing time of 2+1 contribution
-        pathinfo = [[],[],[]]
-        pathinfo[0] = [Lam0,   nan]    # unmodulated part, gives offset
-        pathinfo[1] = [lama,    0 ]    # main modulation, refocusing at time zero
-        pathinfo[2] = [lam21, tau2]    # 2+1 modulation, refocusing at time tau2
+        tau2 = 4                       # refocusing time (us) of 2+1 contribution
+        pathinfo = []
+        pathinfo.append([Lam0])           # unmodulated part, gives offset
+        pathinfo.append([lam1,   0  ])    # main modulation, refocusing at time zero
+        pathinfo.append([lam2,  tau2])    # 2+1 modulation, refocusing at time tau2 
         
         K = dl.dipolarkernel(t,r,pathinfo)
 
 
     References
     ----------
-    .. [1] L. Fábregas Ibáñez, G. Jeschke, and S. Stoll: "DeerLab: A comprehensive toolbox for analyzing dipolar EPR spectroscopy data", Magn. Reson. Discuss., 2020
+    .. [1] L. Fábregas Ibáñez, G. Jeschke, and S. Stoll. DeerLab: A comprehensive toolbox for analyzing dipolar EPR spectroscopy data, Magn. Reson., 1, 209–224, 2020 
 
-    .. [2] Fábregas Ibáñez, L. and Jeschke, G.: Optimal background treatment in dipolar spectroscopy, Physical Chemistry Chemical Physics, 22, 1855–1868, 2020.
+    .. [2] L. Fábregas Ibáñez, and G. Jeschke: Optimal background treatment in dipolar spectroscopy, Physical Chemistry Chemical Physics, 22, 1855–1868, 2020.
 
-    .. [3] Keller, K., Mertens, V., Qi, M., Nalepa, A. I., Godt, A., Savitsky, A., Jeschke, G., and Yulikov, M.: Computing distance distributions from dipolar evolution data with overtones: RIDME spectroscopy with Gd(III)-based spin labels, Physical Chemistry Chemical Physics, 19
+    .. [3] K. Keller, V. Mertens, M. Qi, A. I. Nalepa, A. Godt, A. Savitsky, G. Jeschke, and M. Yulikov: Computing distance distributions from dipolar evolution data with overtones: RIDME spectroscopy with Gd(III)-based spin labels, Physical Chemistry Chemical Physics, 19
 
     .. [4] J.E. Banham, C.M. Baker, S. Ceola, I.J. Day, G.H. Grant, E.J.J. Groenen, C.T. Rodgers, G. Jeschke, C.R. Timmel, Distance measurements in the borderline region of applicability of CW EPR and DEER: A model study on a homologous series of spin-labelled peptides, Journal of Magnetic Resonance, 191, 2, 2008, 202-218
     """
@@ -123,7 +126,6 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
     # Ensure that all inputs are numpy arrays
     r = np.atleast_1d(r)
     t = np.atleast_1d(t)
-    pathinfo = np.atleast_1d(pathinfo)
 
     if type(B) is types.LambdaType:
         ismodelB = True
@@ -140,50 +142,46 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
     if np.any(r<=0):
         raise ValueError("All elements in r must be nonnegative and nonzero.")
 
-    if not np.isreal(pathinfo).all:
-        raise TypeError('lambda/pathinfo must be a numeric array.')
-
+    if not isinstance(pathinfo,list): pathinfo = [pathinfo] 
     if len(pathinfo) == 1:
         lam = pathinfo[0]
-        pathinfo = np.array([[1-lam, np.NaN], [lam, 0]])
-
-    if not np.any(np.shape(pathinfo)[1] != np.array([2, 3])):
-        raise TypeError('pathinfo must be a numeric array with two or three columns.')
-
-    if np.any(np.isnan(pathinfo[:,0])):
-        raise ValueError('In pathinfo, NaN can only appear in the second column (refocusing time) e.g. path[1,:] = [Lam0 NaN]')
+        pathinfo = [[1-lam], [lam, 0]]
 
     # Normalize the pathway amplitudes to unity
-    pathinfo[:,0] = pathinfo[:,0]/sum(pathinfo[:,0])
-    lam = pathinfo[:,0]
-    T0 = pathinfo[:,1]
-    if np.shape(pathinfo)[1] == 2:
-        n = np.ones(np.shape(T0))
-    else:
-        n = pathinfo[:,2]
-    
-    # Combine all unmodulated components into Lambda0, and eliminate from list
-    unmodulated = np.where(np.isnan(T0))
-    Lambda0 = np.sum(lam[unmodulated])
-    lam = np.delete(lam, unmodulated)
-    T0 = np.delete(T0, unmodulated)
-    n = np.delete(n, unmodulated)
-    nModPathways = len(lam)
+    #pathinfo[:,0] = pathinfo[:,0]/sum(pathinfo[:,0])
 
+    paths = [np.atleast_1d(path) for path in pathinfo]
+
+    # Get unmodulated pathways    
+    unmodulated = [paths.pop(i) for i,path in enumerate(paths) if len(path)==1]
+    # Combine all unmodulated contributions
+    Lambda0 = sum(np.concatenate([path for path in unmodulated]))
+
+    # Check structure of pathways
+    for i,path in enumerate(paths):
+        if len(path) == 2:
+            # If harmonic is not defined, append default n=1
+            paths[i] = np.append(path,1) 
+        elif len(path) != 3:
+            # Otherwise paths are not correctly defined
+            raise KeyError('The pathway #{} must be a list of two or three elements [lam, T0] or [lam, T0, n]'.format(i))
+
+    # Define kernel matrix auxiliary function
     kernelmatrix = lambda t: calckernelmatrix(t,r,method,excbandwidth,nKnots,g)
-    
+
     # Build dipolar kernel matrix, summing over all pathways
     K = Lambda0
-    for pathway in range(nModPathways):
-        K = K + lam[pathway]*kernelmatrix(n[pathway]*(t-T0[pathway]))
+    for pathway in paths:
+        lam,T0,n = pathway
+        K = K + lam*kernelmatrix(n*(t-T0))
 
     # Renormalize if requested
     if renormalize:
         Knorm = Lambda0
-        for pathway in range(nModPathways):
-            Knorm = Knorm + lam[pathway]*kernelmatrix(-T0[pathway]*n[pathway])
+        for pathway in paths:
+            lam,T0,n = pathway
+            Knorm = Knorm + lam*kernelmatrix(-T0*n)
         K = K/Knorm
-
 
     # Multiply by background
     if ismodelB:

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -147,9 +147,6 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
         lam = pathinfo[0]
         pathinfo = [[1-lam], [lam, 0]]
 
-    # Normalize the pathway amplitudes to unity
-    #pathinfo[:,0] = pathinfo[:,0]/sum(pathinfo[:,0])
-
     paths = [np.atleast_1d(path) for path in pathinfo]
 
     # Get unmodulated pathways    
@@ -165,6 +162,12 @@ def dipolarkernel(t,r,pathinfo = 1, B = 1, method = 'fresnel', excbandwidth = in
         elif len(path) != 3:
             # Otherwise paths are not correctly defined
             raise KeyError('The pathway #{} must be a list of two or three elements [lam, T0] or [lam, T0, n]'.format(i))
+
+    # Normalize the pathway amplitudes to unity
+    lamsum = Lambda0 + sum([path[0] for path in paths])
+    Lambda0 /= lamsum
+    for i in range(len(paths)):
+        paths[i][0] /= lamsum 
 
     # Define kernel matrix auxiliary function
     kernelmatrix = lambda t: calckernelmatrix(t,r,method,excbandwidth,nKnots,g)

--- a/deerlab/ex_models.py
+++ b/deerlab/ex_models.py
@@ -71,7 +71,7 @@ def ex_4pdeer(param=None):
 
     # Dipolar pathways
     lam = param[0]
-    pathways = np.array([[1-lam, np.NaN], [lam, 0]])
+    pathways = [[1-lam], [lam, 0]]
     
     return pathways
 # ===================================================================
@@ -137,7 +137,7 @@ def ex_ovl4pdeer(param=None):
     # Dipolar pathways
     lam = param[[0,1,2]]
     T02 = param[3]
-    pathways = np.array([[lam[0], np.NaN], [lam[1], 0], [lam[2], T02]])
+    pathways = [[lam[0]], [lam[1], 0], [lam[2], T02]]
     
     return pathways
 # ===================================================================
@@ -203,7 +203,7 @@ def ex_5pdeer(param=None):
     # Dipolar pathways
     lam = param[[0,1,2]]
     T02 = param[3]
-    pathways = np.array([[lam[0], np.NaN], [lam[1], 0], [lam[2], T02]])
+    pathways = [[lam[0]], [lam[1], 0], [lam[2], T02]]
     
     return pathways
 # ===================================================================
@@ -276,7 +276,7 @@ def ex_7pdeer(param=None):
     T02 = param[4]
     T03 = param[5]
 
-    pathways = np.array([[lam[0], np.NaN], [lam[1], 0], [lam[2], T02], [lam[3], T03]])
+    pathways = [[lam[0]], [lam[1], 0], [lam[2], T02], [lam[3], T03]]
     
     return pathways
 # ===================================================================

--- a/docsrc/source/basics.rst
+++ b/docsrc/source/basics.rst
@@ -87,10 +87,9 @@ The returned output is
 
 .. code-block:: python
 
-    pathways =[[0.7,  NaN],
-               [0.3,   0 ]]
+    pathways =[[0.7], [0.3,   0 ]]
 
-Each row of this array holds information about one pathway. The first column is modulation amplitude, and the second column is the refocusing point. In the above example, the first row shows a pathway with amplitude 0.7 and no refocusing time, indicating that it represents the unmodulated contribution. The pathway of the second row shows amplitude of 0.3 and refocusing time 0, i.e. this is the primary dipolar pathway.
+Each nested list holds information about one pathway. The first element is modulation amplitude, and the second element is the refocusing point. In the above example, the first list shows a pathway with amplitude 0.7 and no refocusing time, indicating that it represents the unmodulated contribution. The pathway of the second list shows amplitude of 0.3 and refocusing time 0, i.e. this is the primary dipolar pathway.
 
 Kernel matrices
 --------------------------------------------

--- a/docsrc/source/funding.rst
+++ b/docsrc/source/funding.rst
@@ -1,32 +1,44 @@
 Funding
 ======================
 
-DeerLab has been funded by: 
+DeerLab is a project that has been funded by the following sources:
     
+.. raw:: html 
+
+    <div style="height:100px; width:100%; display:flex; flex-wrap:wrap; align-items:center;">
+         <div style="width=40%; margin-right:8%; font-size:14px">
+            <h3 style="font-size:110%">  ETH Zurich </h3> 
+            Grant ETH-35 18-2
+        </div>
+        <div style="height:70%; width=30%">
+            <img src="./_images/eth_logo.png", style="margin-top:1%; margin-bottom:1%;height:96%;">
+        </div>
+    </div>    
     
+
+.. raw:: html 
+
+    <div style="height:100px; width:100%; display:flex; flex-wrap:wrap; align-items:center;">
+         <div style="margin-right:2%; font-size:14px">
+         <h3 style="font-size:110%">  National Institutes of Health </h3> 
+            Grant GM125753 <br>
+            Grant GM127325
+        </div>
+        <div style="height:70%; width=30%">
+            <img src="./_images/nih_logo.png", style="margin-top:1%; margin-bottom:1%;height:96%;">
+        </div>
+    </div>    
     
-ETH Zurich
-------------
- * **Grant:** ETH-35 18-2
- 
-.. image:: images/eth_logo.png
-   :width: 15%
-   
- 
-National Institutes of Health 
-------------------------------
- * **Grant:** GM125753 
- * **Grant:** GM127325
 
+.. raw:: html 
 
-.. image:: images/nih_logo.png
-   :width: 20%  
-   
-   
-   
-National Science Foundation
-----------------------------
- * **Grant:** CHE-1452967
-
-.. image:: images/nsf_logo.png
-   :width: 10%
+    <div style="height:100px; width:100%; display:flex; flex-wrap:wrap; align-items:center;">
+        <div style="margin-right:2%; font-size:14px">
+            <h3 style="font-size:110%">  National Science Foundation </h3> 
+            Grant CHE-1452967
+        </div>
+        <div style="height:70%; width=30%">
+            <img src="./_images/nsf_logo.png", style="margin-top:1%; margin-bottom:1%;height:96%;">
+        </div>
+    </div>    
+    

--- a/test/test_dipolarbackground.py
+++ b/test/test_dipolarbackground.py
@@ -17,9 +17,9 @@ def test_basic():
 
     #Output
     Bmodel = lambda t,lam: bg_exp(t,kappa,lam)
-    path = np.zeros((2,2))
-    path[0,:] = [1-lam, np.NaN]
-    path[1,:] = [lam, 0]
+    path = [[],[]]
+    path[0] = [1-lam]
+    path[1] = [lam, 0]
     B = dipolarbackground(t,path,Bmodel)
 
     assert max(abs(B-Bref) < 1e-8)
@@ -39,9 +39,9 @@ def test_singletime():
 
     #Output
     Bmodel = lambda t,lam: bg_exp(t,kappa,lam)
-    path = np.zeros((2,2))
-    path[0,:] = [1-lam, np.NaN]
-    path[1,:] = [lam, 0]
+    path = [[],[]]
+    path[0] = [1-lam]
+    path[1] = [lam, 0]
     B = dipolarbackground(t,path,Bmodel)
 
     assert max(abs(B-Bref) < 1e-8)
@@ -61,9 +61,9 @@ def test_harmonics():
 
     #Output
     Bmodel = lambda t,lam: bg_exp(t,kappa,lam)
-    path = np.zeros((2,3))
-    path[0,:] = [1-lam, np.NaN, 1]
-    path[1,:] = [lam, 0, n]
+    path = [[],[]]
+    path[0] = [1-lam]
+    path[1] = [lam, 0,2]
     B = dipolarbackground(t,path,Bmodel)
 
     assert max(abs(B-Bref)) < 1e-8
@@ -99,21 +99,24 @@ def test_multipath_renorm():
     tau2 = 4.92
     t = (tau1 + tau2) - (t1 + t2)
     prob = 0.8
-    lam = np.array([1-prob, prob**2, prob*(1-prob)])
-    T0 = [np.NaN, 0, tau2-t2]
+    lam = [prob**2, prob*(1-prob)]
+    T0 = [0, tau2-t2]
     Bmodel = lambda t,lam: bg_exp(t,kappa,lam)
 
     #Reference
-    unmodulated = np.isnan(T0)
     Bref = 1
     Bnorm = 1
     for p in range(len(lam)):
-        if not unmodulated[p]:
             Bref = Bref*Bmodel((t-T0[p]),lam[p])
             Bnorm = Bnorm*Bmodel(-T0[p],lam[p])
     
+    paths = []
+    paths.append(1-prob)
+    paths.append([prob**2,0])
+    paths.append([prob*(1-prob),tau2-t2])
+
     #Output
-    B = dipolarbackground(t,np.array([lam, T0]).T,Bmodel,renormalize=False)
+    B = dipolarbackground(t,paths,Bmodel,renormalize=False)
 
     assert max(abs(B-Bref)) < 1e-8
 #==================================================================================
@@ -129,28 +132,31 @@ def test_multipath_raw():
     tau2 = 4.92
     t = (tau1 + tau2) - (t1 + t2)
     prob = 0.8
-    lam = np.array([1-prob, prob**2, prob*(1-prob)])
-    T0 = [np.NaN, 0, tau2-t2]
+    lam = [prob**2, prob*(1-prob)]
+    T0 = [0, tau2-t2]
     Bmodel = lambda t,lam: bg_exp(t,kappa,lam)
 
     #Reference
-    unmodulated = np.isnan(T0)
     Bref = 1
     Bnorm = 1
     for p in range(len(lam)):
-        if not unmodulated[p]:
             Bref = Bref*Bmodel((t-T0[p]),lam[p])
             Bnorm = Bnorm*Bmodel(-T0[p],lam[p])
     Bref = Bref/Bnorm
     
+    paths = []
+    paths.append(1-prob)
+    paths.append([prob**2,0])
+    paths.append([prob*(1-prob),tau2-t2])
+
     #Output
-    B = dipolarbackground(t,np.array([lam, T0]).T,Bmodel)
+    B = dipolarbackground(t,paths,Bmodel)
 
     assert max(abs(B-Bref)) < 1e-8
 #==================================================================================
 
 def test_overtones():
-
+#==================================================================================
     t = np.linspace(0,5,150)
     kappa = 0.3
     lam = 0.5
@@ -163,10 +169,13 @@ def test_overtones():
     
     # Output
     Bmodel = lambda t,lam: bg_exp(t,kappa,lam)
-    path = np.zeros((2,2))
-    path[0,:] = [1-lam, np.NaN]
-    path[1,:] = [lam, 0]
+    path = []
+    path.append([1-lam])
+    path.append([overtones[0]*lam, 0, 1])
+    path.append([overtones[1]*lam, 0, 2])
+    path.append([overtones[2]*lam, 0, 3])
 
-    B = dipolarbackground(t,path,Bmodel,overtonecoeff=overtones)
+    B = dipolarbackground(t,path,Bmodel)
 
     assert max(abs(B-Bref)) < 1e-8
+#==================================================================================

--- a/test/test_fitsignal.py
+++ b/test/test_fitsignal.py
@@ -16,11 +16,11 @@ def assert_experiment_model(model):
 
     info = model()
     parIn = info['Start']
-    pathinfo = model(parIn)
+    pathways = model(parIn)
 
     kappa = 0.4
     Bmodel = lambda t,lam: bg_exp(t,kappa,lam)
-    K = dipolarkernel(t,r,pathinfo,Bmodel)
+    K = dipolarkernel(t,r,pathways,Bmodel)
     V = K@P
 
     fit = fitsignal(V,t,r,'P',bg_exp,model,uqanalysis=False)
@@ -163,15 +163,15 @@ def test_global_4pdeer():
 
     info = ex_4pdeer()
     parIn = info['Start']
-    pathinfo = ex_4pdeer(parIn)
+    pathways = ex_4pdeer(parIn)
 
     kappa = 0.4
     Bmodel = lambda t,lam: bg_exp(t,kappa,lam)
 
     t1 = np.linspace(0,5,100)
-    V1 = dipolarkernel(t1,r,pathinfo,Bmodel)@P
+    V1 = dipolarkernel(t1,r,pathways,Bmodel)@P
     t2 = np.linspace(0,5,250)
-    V2 = dipolarkernel(t2,r,pathinfo,Bmodel)@P
+    V2 = dipolarkernel(t2,r,pathways,Bmodel)@P
     
     fit = fitsignal([V1,V2],[t1,t2],r,'P',bg_exp,ex_4pdeer,uqanalysis=False)
 
@@ -268,14 +268,14 @@ def assert_confinter_param(subset):
 
     info = exmodel()
     parIn = info['Start']
-    pathinfo = exmodel(parIn)
+    pathways = exmodel(parIn)
 
     kappa = 0.4
     Bmodel = lambda t,lam: bgmodel(t,kappa,lam)
 
     t = np.linspace(0,5,100)
     np.random.seed(0)
-    V = dipolarkernel(t,r,pathinfo,Bmodel)@P + whitegaussnoise(t,0.01)
+    V = dipolarkernel(t,r,pathways,Bmodel)@P + whitegaussnoise(t,0.01)
     
     fit = fitsignal(V,t,r,ddmodel,bgmodel,exmodel,uqanalysis=True)
 
@@ -334,14 +334,14 @@ def assert_confinter_models(subset):
 
     info = exmodel()
     parIn = info['Start']
-    pathinfo = exmodel(parIn)
+    pathways = exmodel(parIn)
 
     kappa = 0.4
     Bmodel = lambda t,lam: bgmodel(t,kappa,lam)
 
     t = np.linspace(0,5,100)
     np.random.seed(0)
-    V = dipolarkernel(t,r,pathinfo,Bmodel)@P + whitegaussnoise(t,0.03)
+    V = dipolarkernel(t,r,pathways,Bmodel)@P + whitegaussnoise(t,0.03)
     
     fit = fitsignal(V,t,r,ddmodel,bgmodel,exmodel,uqanalysis=True)
 
@@ -450,15 +450,15 @@ def test_global_scale_4pdeer():
 
     info = ex_4pdeer()
     parIn = info['Start']
-    pathinfo = ex_4pdeer(parIn)
+    pathways = ex_4pdeer(parIn)
 
     kappa = 0.4
     Bmodel = lambda t,lam: bg_exp(t,kappa,lam)
     scales = [1e3,1e9]
     t1 = np.linspace(0,5,100)
-    V1 = scales[0]*dipolarkernel(t1,r,pathinfo,Bmodel)@P
+    V1 = scales[0]*dipolarkernel(t1,r,pathways,Bmodel)@P
     t2 = np.linspace(0,5,250)
-    V2 = scales[1]*dipolarkernel(t2,r,pathinfo,Bmodel)@P
+    V2 = scales[1]*dipolarkernel(t2,r,pathways,Bmodel)@P
     
     fit = fitsignal([V1,V2],[t1,t2],r,'P',bg_exp,ex_4pdeer,uqanalysis=False)
 


### PR DESCRIPTION
See #39 
Simplified the interface for defining dipolar pathways in `dipolarkernel` and `dipolarbackground`. Instead of using a matrix for defining the pathways, using NaN for unmodulated pathways, these are now defined as a list of pathways, each being a list of parameters.

Refactored and simplified code for both functions profiting the new interface. 