### PR TITLE
Better handling of UncertQuant object under disabled uncertainty analysis

### DIFF
--- a/deerlab/classes.py
+++ b/deerlab/classes.py
@@ -97,8 +97,6 @@ class UncertQuant:
 
     def __init__(self,uqtype,data=[],covmat=[],lb=[],ub=[]):
 
-        global _uqtype
-
         #Parse inputs schemes
         if uqtype=='covariance':
             # Scheme 1: UncertQuant('covariance',parfit,covmat,lb,ub)
@@ -200,7 +198,7 @@ class UncertQuant:
             # Get bw using silverman's rule (1D only)
             samplen = self.samples[:, n]
             sigma = np.std(samplen, ddof=1)
-            bw = sigma * (len(samplen) * 3 / 4.0) ** (-1 / 5)
+            bw = sigma*(len(samplen)*3/4.0)**(-1/5)
 
             # Make histogram
             maxbin = np.maximum(np.max(samplen),np.mean(samplen)+3*sigma)
@@ -274,11 +272,11 @@ class UncertQuant:
         
         Returns
         -------
-        cis : 2D-ndarray
+        ci : 2D-ndarray
             Confidence intervals for the parameters:
 
-                * ``cis[:,0]`` - Lower confidence intervals
-                * ``cis[:,1]`` - Upper confidence intervals
+                * ``ci[:,0]`` - Lower confidence intervals
+                * ``ci[:,1]`` - Upper confidence intervals
         """
         if coverage>100 or coverage<0:
             raise ValueError('The input must be a number between 0 and 100')

--- a/deerlab/classes.py
+++ b/deerlab/classes.py
@@ -152,11 +152,11 @@ class UncertQuant:
     # Gets called when an attribute is accessed
     #--------------------------------------------------------------------------------
     def __getattribute__(self, attr):
-        # Calling the super class to avoid recursion
         try:
-            # Check if the uncertainty quantification has been done, if not report that there is nothing in the object
+            # Calling the super class to avoid recursion
             if super(UncertQuant, self).__getattribute__('type') == 'void':
-                raise ValueError('The requested attribute is not available. Uncertainty quantification has not been calculated during the fit by using the `uqanalysis=False` keyword.')
+                # Check if the uncertainty quantification has been done, if not report that there is nothing in the object
+                raise ValueError('The requested attribute/method is not available. Uncertainty quantification has not been calculated during the fit by using the `uqanalysis=False` keyword.')
         except AttributeError:
             # Catch cases where 'type' attribute has still not been defined (e.g. when using copy.deepcopy)
             pass

--- a/deerlab/fitmultimodel.py
+++ b/deerlab/fitmultimodel.py
@@ -382,8 +382,8 @@ def fitmultimodel(V, Kmodel, r, model, maxModels, method='aic', lb=None, ub=None
         amps_subset = np.arange(P_subset[-1]+1, P_subset[-1]+1+Nopt)
         Puq = paramuq.propagate(lambda p: Pmodel(p[P_subset],p[amps_subset]), np.zeros(len(r)))
     else: 
-        Puq = []
-        paramuq = []
+        Puq = dl.UncertQuant('void')
+        paramuq = dl.UncertQuant('void')
 
     # Goodness of fit
     stats = []

--- a/deerlab/fitparamodel.py
+++ b/deerlab/fitparamodel.py
@@ -228,7 +228,7 @@ def fitparamodel(V, model, par0=[],lb=[],ub=[], weights = 1,
         # Construct confidence interval structure
         paruq = UncertQuant('covariance',parfit,covmatrix,lb,ub)
     else:
-        paruq = []
+        paruq = UncertQuant('void')
 
     # Calculate goodness of fit
     stats = []

--- a/deerlab/fitregmodel.py
+++ b/deerlab/fitregmodel.py
@@ -177,7 +177,8 @@ def fitregmodel(V,K,r, regtype='tikhonov', regparam='aic', regorder=2, solver='c
         NonNegConst = np.zeros(len(r))
         Puq = UncertQuant('covariance',Pfit,covmat,NonNegConst,[])
     else:
-        Puq = []
+        Puq = UncertQuant('void')
+
     
     # Re-normalization of the distributions
     # --------------------------------------

--- a/deerlab/fitsignal.py
+++ b/deerlab/fitsignal.py
@@ -530,13 +530,13 @@ def fitsignal(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
         modfituq['Bfit'] = [Bfit_uq[j] for j in range(nSignals)]
     else:
         paruq = dict()
-        paruq['dd'] = []
-        paruq['bg'] = []
-        paruq['ex'] = []
+        paruq['dd'] = UncertQuant('void')
+        paruq['bg'] = UncertQuant('void')
+        paruq['ex'] = UncertQuant('void')
         modfituq = dict()
-        modfituq['Pfit'] = []
-        modfituq['Vfit'] = []
-        modfituq['Bfit'] = []
+        modfituq['Pfit'] = UncertQuant('void')
+        modfituq['Vfit'] = UncertQuant('void')
+        modfituq['Bfit'] = UncertQuant('void')
 
     Vfit_ = Vfit
     def _display_results():


### PR DESCRIPTION
When the uncertainty quantification analysis is disabled in the fit functions (`uqanalysis=False`), the corresponding output is returned as an empty list. This can lead to errors such as the one described in #54. 

These changes will now prompt instead an exception to inform that the data is not available: 

```
ValueError: The requested attribute is not available. Uncertainty quantification has not 
been calculated during the fit by using the `uqanalysis=False` keyword.
```