### PR TITLE
Fix GH-pages deployment

### DIFF
--- a/.github/workflows/deploy_ghpages.yml
+++ b/.github/workflows/deploy_ghpages.yml
@@ -1,9 +1,9 @@
 name: Docs Build & Deployment
 
 on: 
-  push:
+  pull_request:
     branches:
-    - manual_ghp_update
+    - main
     paths:
     - 'docsrc/**'
     - '.github/workflows/deploy_ghpages.yml'

--- a/.github/workflows/deploy_ghpages.yml
+++ b/.github/workflows/deploy_ghpages.yml
@@ -6,6 +6,7 @@ on:
     - manual_ghp_update
     paths:
     - 'docsrc/**'
+    - '.github/workflows/deploy_ghpages.yml'
   release:
     types: [published]
 
@@ -30,12 +31,12 @@ jobs:
     - name: Install dependencies
       run: |
            python -m pip install --upgrade pip
-           python -m pip install sphinx==1.8.0
            python -m pip install sphinx_rtd_theme
            python -m pip install numpydoc
            python -m pip install sphinx-gallery
            python -m pip install sphinxcontrib-httpdomain
            python -m pip install m2r2
+           python -m pip install sphinx==1.8.4
            sudo apt install texlive-extra-utils
            sudo apt-get install texlive-latex-extra
            python -m pip install .


### PR DESCRIPTION
The DeerLab build requires an older version of Sphinx, however some package during the installation (probably `sphinx-gallery` was updating Sphinx to the latest release). With the newest release (3.3.0) the action crashed. 