### PR TITLE
New CSD algorithm to avoid LAPACK crash during GSVD

### DIFF
--- a/deerlab/regparamrange.py
+++ b/deerlab/regparamrange.py
@@ -34,12 +34,8 @@ def regparamrange(K,L,noiselvl=0,logres=0.1):
     # Scaling by noise. This improves L curve corner detection for DEER.
     minmax_ratio = minmax_ratio*2**(noiselvl/0.0025)
 
-    try:
-        # Get generalized singular values of K and L
-        singularValues = gsvd(K,L)
-    except:
-        # Otherwise just estimate via the SVD from the dipolar kernel to avoid crash
-        _,singularValues,_ = svd(K)
+    # Get generalized singular values of K and L
+    singularValues = gsvd(K,L)
 
     DerivativeOrder = L.shape[1] - L.shape[0] # get order of derivative (=number of inf in singval)
     singularValues = singularValues[0:len(singularValues)-DerivativeOrder] # remove inf 

--- a/deerlab/utils/utils.py
+++ b/deerlab/utils/utils.py
@@ -249,7 +249,7 @@ def gsvd(A,B):
 #===============================================================================
 
 
-def csd(q1,q2):
+def csd(Q1,Q2):
 #===============================================================================
     """
     Cosine-Sine Decomposition
@@ -269,10 +269,10 @@ def csd(q1,q2):
     http://www.ar-tiste.com/m-fun/m-fun-index.html
 
     """
-    m,n = q1.shape
-    p,_ = q2.shape
+    m,n = Q1.shape
+    p,_ = Q2.shape
     if m < p:
-        s,c = csd(q2,q1)
+        s,c = csd(Q2,Q1)
         j = np.flip(np.arange(n)) 
         c = c[:,j] 
         s = s[:,j] 
@@ -284,7 +284,7 @@ def csd(q1,q2):
         s[np.arange(n),:] = s[i,:] 
         return c,s
 
-    _,sdiag,v = np.linalg.svd(q1)
+    _,sdiag,v = np.linalg.svd(Q1)
     c = np.zeros((m, n))
     np.fill_diagonal(c, sdiag)
     v = v.T.conj()
@@ -292,13 +292,13 @@ def csd(q1,q2):
     z = scp.linalg.hankel(z[:,n-1])
     c[0:n,:] = z@c[0:n,:]@z
     v = v@z
-    q2 = q2@v
+    Q2 = Q2@v
     k=0
     for j in range(1,n):
         if c[j,j] <= 1/np.sqrt(2): k=j
-    b = q2[:,0:k]
+    b = Q2[:,0:k]
     u2,r = np.linalg.qr(b,mode='complete')
-    s = u2.T@q2
+    s = u2.T@Q2
     t = np.minimum(p,n)
     tt = np.minimum(m,p)
     if k<t:

--- a/deerlab/utils/utils.py
+++ b/deerlab/utils/utils.py
@@ -232,148 +232,94 @@ def gsvd(A,B):
         QB = QB[:,0:p]
         n = p
 
-
     Q,_ = np.linalg.qr(np.vstack((A,B)), mode='reduced')
     Q1 = Q[0:m,0:p]
     Q2 = Q[m:m+n,0:p]
-    U,_,_,C,S = csd(Q1,Q2)
+    C,S = csd(Q1,Q2)
 
     # Vector of generalized singular values.
     q = min(m+n,p)
     # Supress divide by 0 warning        
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        U = np.vstack((np.zeros((q-m,1),'double'), np.diag(C,max(0,q-m)).reshape(len(np.diag(C,max(0,q-m))),1))) /  np.vstack((np.diag(S,0).reshape(len(np.diag(S,0)),1), np.zeros((q-n,1),'double') ))
+        U = np.vstack((np.zeros((q-m,1),'double'), np.diag(C,max(0,q-m)).reshape(len(np.diag(C,max(0,q-m))),1)))/np.vstack((np.diag(S,0).reshape(len(np.diag(S,0)),1), np.zeros((q-n,1),'double') ))
 
 
     return U
 #===============================================================================
 
 
-def csd(Q1,Q2):
+def csd(q1,q2):
 #===============================================================================
     """
     Cosine-Sine Decomposition
-
-    U,V,Z,C,S = csd(Q1,Q2)
-
-    Given Q1 and Q2 such that Q1'@Q1 + Q2'@Q2 = I, the
-    C-S Decomposition is a joint factorization of the form
-    Q1 = U@C@Z' and Q2=V@S@Z'
-    where U, V, and Z are orthogonal matrices and C and S
-    are diagonal matrices (not necessarily square) satisfying
-    C'@C + S'@S = I
-    """
-    [m,p] = np.shape(Q1)
-    n = np.shape(Q2)[0]
-
-
-    if m < n:
-        V,U,Z,S,C = csd(Q2,Q1)
-        j = np.flip(np.arange(p)) 
-        C = C[:,j] 
-        S = S[:,j] 
-        Z = Z[:,j]
-        m = min(m,p) 
-        i =  np.flip(np.arange(m)) 
-        C[np.arange(m),:] = C[i,:] 
-        U[:,np.arange(m)] = U[:,i]
-        n = min(n,p) 
-        i =  np.flip(np.arange(n)) 
-        S[np.arange(n),:] = S[i,:] 
-        V[:,np.arange(n)] = V[:,i]
-        return U,V,Z,C,S
+    -------------------------
     
-    U,sdiag,VH = np.linalg.svd(Q1)
-    C= np.zeros((m, p))
-    np.fill_diagonal(C, sdiag)
-    Z = VH.T.conj()
+    Given Q1 and Q2 such that Q1'* Q1 + Q2'* Q2 = I, the
+    C-S Decomposition is a joint factorization of the form
+          Q1 = U1*C*V' and Q2=U2*S*V'
+    where U1,U2,V are orthogonal matrices and C and S are diagonal
+    matrices (not necessarily square) satisfying
+             C'* C + S'* S = I
+    The diagonal entries of C and S are nonnegative and the
+    diagonal elements of C are in nondecreasing order.
+    The matrix Q1 cannot have more columns than rows.
 
-    q = min(m,p)
-    i = np.arange(0, q, 1)
-    j = np.arange(q-1, -1, -1)
-    C[i,i] = C[j,j]
-    U[:,i] = U[:,j]
-    Z[:,i] = Z[:,j]
-    S = Q2@Z
+    Based on the Octave code by Artiste (submitted by S.J.Leon): 
+    http://www.ar-tiste.com/m-fun/m-fun-index.html
 
-    if q == 1:
-        k = 0
-    elif m < p:
-        k = n
-    else:
-        k = max(0, np.max(np.where(np.diag(C) <= 1/math.sqrt(2))))
-    V,_ = scp.linalg.qr(S[:,0:k])
-
-    S = V.T@S
-    r = min(k,m)
-    S[:,0:r-1] = diagf(S[:,0:r-1])
-
-    if (m == 1 and p > 1):
-        S[0,0] = 0
-
-    if k < min(n,p):
-        r = min(n,p)
-        i = np.arange(k, n, 1)
-        j = np.arange(k, r, 1)
-        [UT,STdiag,VH] = np.linalg.svd(S[np.ix_(i,j)])
-        ST = np.zeros((len(i), len(j)))
-        np.fill_diagonal(ST, STdiag)
-        VT = VH.T.conj()
-        if k > 0:
-            S[0:k,j] = 0
-        S[np.ix_(i,j)] = ST
-        C[:,j] = C[:,j]@VT
-        V[:,i] = V[:,i]@UT
-        Z[:,j] = Z[:,j]@VT
-        i = np.arange(k, q, 1)
-        [Q,R] = scp.linalg.qr(C[np.ix_(i,j)])
-        C[np.ix_(i,j)] = diagf(R)
-        U[:,i] = U[:,i]@Q
-
+    """
+    m,n = q1.shape
+    p,_ = q2.shape
     if m < p:
-        # Diagonalize final block of S and permute blocks.
-        eps = np.finfo(float).eps
-        q = min([np.count_nonzero(abs(np.diag(C,0))>10*m*eps),
-                np.count_nonzero(abs(np.diag(S,0))>10*n*eps),
-                np.count_nonzero(np.amax(abs(S[:,m+1:p]),axis = 1)<np.sqrt(eps))])
+        s,c = csd(q2,q1)
+        j = np.flip(np.arange(n)) 
+        c = c[:,j] 
+        s = s[:,j] 
+        m = np.minimum(m,p) 
+        i =  np.flip(np.arange(m)) 
+        c[np.arange(m),:] = c[i,:] 
+        n = np.minimum(n,p) 
+        i =  np.flip(np.arange(n)) 
+        s[np.arange(n),:] = s[i,:] 
+        return c,s
 
-        # maxq: maximum size of q such that the expression used later on,
-        #        i = [q+1:q+p-m, 1:q, q+p-m+1:n],
-        # is still a valid permutation.
-        maxq = m + n - p
-        q = q + np.count_nonzero(np.amax(abs(S[:,q+1:maxq+1]),axis = 1)>np.sqrt(eps))
+    _,sdiag,v = np.linalg.svd(q1)
+    c = np.zeros((m, n))
+    np.fill_diagonal(c, sdiag)
+    v = v.T.conj()
+    z = np.eye(n,n)
+    z = scp.linalg.hankel(z[:,n-1])
+    c[0:n,:] = z@c[0:n,:]@z
+    v = v@z
+    q2 = q2@v
+    k=0
+    for j in range(1,n):
+        if c[j,j] <= 1/np.sqrt(2): k=j
+    b = q2[:,0:k]
+    u2,r = np.linalg.qr(b,mode='complete')
+    s = u2.T@q2
+    t = np.minimum(p,n)
+    tt = np.minimum(m,p)
+    if k<t:
+        r2 = s[np.ix_(range(k,p),range(k,t))]
+        _,sdiag,vt = np.linalg.svd(r2)
+        ss= np.zeros(r2.shape)
+        np.fill_diagonal(ss, sdiag)
+        vt = vt.T.conj()
+        s[k:p,k:t] = ss
+        c[:,k:t] = c[:,k:t]@vt
+        w = c[k:tt,k:t]
+        z,r = np.linalg.qr(w,mode='complete')
+        c[k:tt,k:t] = r
+    for j in range(n):
+        if c[j,j]<0:
+            c[j,j]  = -c[j,j]
+    for j in range(t):
+        if s[j,j]<0:
+            s[j,j]  = -s[j,j]
 
-        i = np.arange(q,n,1)
-        j = np.arange(m,p,1)
-        # At this point, S(i,j) should have orthogonal columns and the
-        # elements of S(:,q+1:p) outside of S(i,j) should be negligible.
-        Q,R = scp.linalg.qr(S[np.ix_(i,j)])
-        S[:,q+1:p] = 0
-        S[np.ix_(i,j)] = diagf(R)
-        V[:,i] = V[:,i]@Q
-        if n > 1:
-            i = np.concatenate((np.arange(q,q+p-m,1), np.arange(0,q,1), np.arange(q+p-m,n,1)))
-        else:
-            i = 1
-        j = np.concatenate((np.arange(m,p,1), np.arange(0,m,1)))
-        C = C[:,j]
-        S = S[np.ix_(i,j)]
-        Z = Z[:,j]
-        V = V[:,i]
-
-    if n < p:
-        #Final block of S is negligible.
-        S[:,n+1:p] = 0
-
-    # Make sure C and S are real and positive.
-    U,C = diagp(U,C,max(0,p-m))
-    C = C.real
-
-    V,S = diagp(V,S,0)
-    S = S.real
-
-    return U,V,Z,C,S
+    return c,s
 #===============================================================================
 
 #===============================================================================


### PR DESCRIPTION
Resolves #42

New implementation of a cosine-sine decomposition (CSD) algorithm that does not suffer from the LAPACK crashes observed in the previous implementation (see #42 for details). 

Used the following benchmark to test the new implementation: 
````python
Npass = 0
Nfails = 0
alphamin2 = np.full(N,np.nan)
alphamax2 = np.full(N,np.nan)
for i in range(N):

    np.random.seed(i)
    tmax = np.random.uniform(2,8)
    rmax = np.random.uniform(2,8)
    nt = np.random.randint(80,900)
    nr = np.random.randint(80,900)
    lam = 0.1+0.9*np.random.rand(1)
    c = np.random.randint(5,500)

    t = np.linspace(-0.3,tmax,nt)
    r = np.linspace(1,rmax,nr)
    B = dl.bg_hom3d(t,c,lam)
    try:
        K = dl.dipolarkernel(t,r,lam,B)
        L = dl.regoperator(r,2)
        alphasnew = newregparamrange(K,L)
        alphamax2[i] = alphasnew.max()
        alphamin2[i] = alphasnew.min()
        Npass += 1
    except: 
        Nfails += 1

plt.pie([Npass,Nfails],labels=['Pass','Fails'],autopct='%1.1f%%',
        shadow=True, startangle=90)
plt.show()
````

**Benchmark with previous implementation:**
![pic1](https://user-images.githubusercontent.com/48292540/103455237-c3be8280-4ceb-11eb-9b1b-201901b5e714.png)

**Benchmark with new implementation:**
![pic2](https://user-images.githubusercontent.com/48292540/103455255-eb154f80-4ceb-11eb-8505-dc8c261420ba.png)

The computed alpha-values also seem to be correct, with some deviations in some cases. Usually leading to smaller minima of the alphas-range. 