### PR TITLE
Simplification of the inital and boundary values interface for fitsignal

### DIFF
--- a/deerlab/fitsignal.py
+++ b/deerlab/fitsignal.py
@@ -14,8 +14,8 @@ from deerlab.ex_models import ex_4pdeer
 from deerlab.utils import isempty, goodness_of_fit, Jacobian
 
 def fitsignal(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
-              par0_dd=None, par0_bg=None, par0_ex=None, verbose= False,
-              lb_dd=None, lb_bg=None, lb_ex=None, ub_dd=None, ub_bg=None, ub_ex=None,
+              dd_par0=None, bg_par0=None, ex_par0=None, verbose= False,
+              dd_lb=None, bg_lb=None, ex_lb=None, dd_ub=None, bg_ub=None, ex_ub=None,
               weights=1, uqanalysis=True, regparam='aic', regtype = 'tikhonov'):
     r"""
     Fits a dipolar model to the experimental signal ``V`` with time axis ``t``, using
@@ -66,20 +66,20 @@ def fitsignal(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
 
         The default is ``ex_4pdeer``.
 
-    par0_dd, par0_bg, par0_ex : array_like, optional
+    dd_par0, bg_par0, ex_par0 : array_like, optional
         Initial parameter values of the distance distribution/background/experimental model parameters.
-        If a model does not require parameters or are to be determined automatically it must be specified 
-        a ``None`` (default).
+        If a model does not require parameters or are to be determined automatically it can be omitted or specified 
+        as ``None`` (default).
     
-    lb_dd, lb_bg, lb_ex : array_like, optional    
+    dd_lb, bg_lb, ex_lb : array_like, optional    
         Lower boundary values of the distance distribution/background/experimental model parameters.
-        If a model does not require parameters or are to be determined automatically it must be specified 
-        a ``None`` (default).
+        If a model does not require parameters or are to be determined automatically it can be omitted or specified 
+        as ``None`` (default).
     
-    ub_dd, ub_bg, ub_ex : array_like, optional    
+    dd_ub, bg_ub, ex_ub : array_like, optional    
         Upper boundary values of the distance distribution/background/experimental model parameters.
-        If a model does not require parameters or are to be determined automatically it must be specified 
-        a ``None`` (default).
+        If a model does not require parameters or are to be determined automatically it can be omitted or specified 
+        as ``None`` (default).
     
     weights : array_like, optional
         Array of weighting coefficients for the individual signals in global fitting,
@@ -228,9 +228,9 @@ def fitsignal(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
     if len(ex_model)!=nSignals:
         ex_model = ex_model*nSignals
 
-    par0 = [[] if par0_i is None else par0_i for par0_i in [par0_dd,par0_bg,par0_ex]]
-    lb = [[] if lb_i is None else lb_i for lb_i in [lb_dd,lb_bg,lb_ex]]
-    ub = [[] if ub_i is None else ub_i for ub_i in [ub_dd,ub_bg,ub_ex]]
+    par0 = [[] if par0_i is None else par0_i for par0_i in [dd_par0,bg_par0,ex_par0]]
+    lb = [[] if lb_i is None else lb_i for lb_i in [dd_lb,bg_lb,ex_lb]]
+    ub = [[] if ub_i is None else ub_i for ub_i in [dd_ub,bg_ub,ex_ub]]
     if type(par0) is not list or len(par0)!=3:
         raise TypeError('Initial parameters (7th input) must be a 3-element cell array.')
      

--- a/deerlab/fitsignal.py
+++ b/deerlab/fitsignal.py
@@ -6,7 +6,6 @@
 import numpy as np
 import types
 import copy
-import inspect
 import matplotlib.pyplot as plt
 import deerlab as dl
 from deerlab.classes import UncertQuant, FitResult
@@ -15,7 +14,8 @@ from deerlab.ex_models import ex_4pdeer
 from deerlab.utils import isempty, goodness_of_fit, Jacobian
 
 def fitsignal(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
-              par0=[None,None,None], lb=[None,None,None], ub=[None,None,None], verbose= False,
+              par0_dd=None, par0_bg=None, par0_ex=None, verbose= False,
+              lb_dd=None, lb_bg=None, lb_ex=None, ub_dd=None, ub_bg=None, ub_ex=None,
               weights=1, uqanalysis=True, regparam='aic', regtype = 'tikhonov'):
     r"""
     Fits a dipolar model to the experimental signal ``V`` with time axis ``t``, using
@@ -231,9 +231,9 @@ def fitsignal(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
     if len(ex_model)!=nSignals:
         ex_model = ex_model*nSignals
 
-    par0 = [[] if par0_i is None else par0_i for par0_i in par0]
-    lb = [[] if lb_i is None else lb_i for lb_i in lb]
-    ub = [[] if ub_i is None else ub_i for ub_i in ub]
+    par0 = [[] if par0_i is None else par0_i for par0_i in [par0_dd,par0_bg,par0_ex]]
+    lb = [[] if lb_i is None else lb_i for lb_i in [lb_dd,lb_bg,lb_ex]]
+    ub = [[] if ub_i is None else ub_i for ub_i in [ub_dd,ub_bg,ub_ex]]
     if type(par0) is not list or len(par0)!=3:
         raise TypeError('Initial parameters (7th input) must be a 3-element cell array.')
      

--- a/deerlab/fitsignal.py
+++ b/deerlab/fitsignal.py
@@ -66,23 +66,20 @@ def fitsignal(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
 
         The default is ``ex_4pdeer``.
 
-    par0 : list of array_like, optional
-        Starting parameter values. Must be a 3-element list ``[par0_dd,par0_bg,par0_ex]``
-        containing the start values of the distribution, background and experiment models, in that order.
+    par0_dd, par0_bg, par0_ex : array_like, optional
+        Initial parameter values of the distance distribution/background/experimental model parameters.
         If a model does not require parameters or are to be determined automatically it must be specified 
-        as an empty list ``[]``. The default is ``par0=[[],[],[]]``.
+        a ``None`` (default).
     
-    lb : list of array_like, optional
-        Lower bounds for parameters.  Must be a 3-element list ``[lb_dd,lb_bg,lb_ex]``
-        containing the start values of the distribution, background and experiment models, in that order.
+    lb_dd, lb_bg, lb_ex : array_like, optional    
+        Lower boundary values of the distance distribution/background/experimental model parameters.
         If a model does not require parameters or are to be determined automatically it must be specified 
-        as an empty list ``[]``. The default is ``lb=[[],[],[]]``.
+        a ``None`` (default).
     
-    ub : list of array_like, optional
-        Upper bounds for parameters, Must be a 3-element list ``[ub_dd,ub_bg,ub_ex]``
-        containing the start values of the distribution, background and experiment models, in that order.
+    ub_dd, ub_bg, ub_ex : array_like, optional    
+        Upper boundary values of the distance distribution/background/experimental model parameters.
         If a model does not require parameters or are to be determined automatically it must be specified 
-        as an empty list ``[]``. The default is ``ub=[[],[],[]]``.
+        a ``None`` (default).
     
     weights : array_like, optional
         Array of weighting coefficients for the individual signals in global fitting,

--- a/examples/plot_extracting_gauss_constraints.py
+++ b/examples/plot_extracting_gauss_constraints.py
@@ -34,6 +34,7 @@ V = K@P + dl.whitegaussnoise(t,0.01,seed=0)   # DEER trace, with added noise
 # %%
 fit = dl.fitsignal(V,t,r,'P',dl.bg_exp,dl.ex_4pdeer)
 fit.plot()
+plt.show() 
 
 # %% [markdown]
 # Fit Gaussians to the distance distribution

--- a/examples/plot_fitting_5pdeer.py
+++ b/examples/plot_fitting_5pdeer.py
@@ -42,18 +42,8 @@ ex_ub   = [100, 100, 100, max(t)/2+1] # upper bounds
 ex_par0 = [0.5, 0.5, 0.5, max(t)/2  ] # start values
 
 # %% [markdown]
-# In this case we only want to set the bounds for the experiment
-# parameters, so we can leave the rest empty:
-# 
-
-# %%
-ub = [[],[],ex_ub]
-lb = [[],[],ex_lb]
-par0 = [[],[],ex_par0]
-
-# %% [markdown]
 # Run the fit with a 5-pulse DEER signal model
 
 # %%
-fit = dl.fitsignal(Vexp,t,r,'P',dl.bg_hom3d,dl.ex_5pdeer,par0,lb,ub)
+fit = dl.fitsignal(Vexp,t,r,'P',dl.bg_hom3d,dl.ex_5pdeer,par0_ex=ex_par0,lb_ex=ex_lb,ub_ex=ex_ub)
 fit.plot()

--- a/examples/plot_fitting_5pdeer.py
+++ b/examples/plot_fitting_5pdeer.py
@@ -36,6 +36,8 @@ Vexp = K@P + dl.whitegaussnoise(t,0.005,seed=1)
 # pathway amplitudes pretty much unconstrained.
 # 
 
+# %% [markdown]
+# Define initial values and bounds for model parameters
 # %%
 ex_lb   = [ 0,   0,   0,  max(t)/2-1] # lower bounds
 ex_ub   = [100, 100, 100, max(t)/2+1] # upper bounds

--- a/examples/plot_fitting_mixed_model.py
+++ b/examples/plot_fitting_mixed_model.py
@@ -44,7 +44,7 @@ V = K @ P + dl.whitegaussnoise(t,0.02,seed=0)
 #
 # Let's say our intuiton (which, since we know the ground truth, is exact) on 
 # the sample indicates that our distribution is a llinear combination of a Gaussian 
-# distirbution and a worm-like chain model. While DeerAnalysis provides built-in 
+# distirbution and a worm-like chain model. While DeerLab provides built-in 
 # parametric models for both models, we require a combination of both. 
 #
 # For such cases we can use the ``mixmodels`` function to create a custom mixed 

--- a/examples/plot_fitting_mixed_model.py
+++ b/examples/plot_fitting_mixed_model.py
@@ -44,7 +44,7 @@ V = K @ P + dl.whitegaussnoise(t,0.02,seed=0)
 #
 # Let's say our intuiton (which, since we know the ground truth, is exact) on 
 # the sample indicates that our distribution is a llinear combination of a Gaussian 
-# distirbution and a worm-like chain model. While DeerLab provides built-in 
+# distribution and a worm-like chain model. While DeerLab provides built-in 
 # parametric models for both models, we require a combination of both. 
 #
 # For such cases we can use the ``mixmodels`` function to create a custom mixed 

--- a/examples/plot_param_uncertainty_propagation.py
+++ b/examples/plot_param_uncertainty_propagation.py
@@ -132,6 +132,7 @@ plt.ylabel('P(r) [nm$^{-1}$]')
 plt.grid(alpha=0.3)
 plt.legend(['truth','Pfit','Pfit 95%-CI'])
 
+plt.show()
 
 # %%
 

--- a/examples/plot_pseudotitration_parameter_free.py
+++ b/examples/plot_pseudotitration_parameter_free.py
@@ -182,6 +182,5 @@ plt.ylabel('Fractions')
 plt.legend(['state A','state B'])
 plt.ylim([0,1])
 
-plt.tight_layout()
 plt.show()
 # %%

--- a/test/test_fitsignal.py
+++ b/test/test_fitsignal.py
@@ -126,7 +126,7 @@ def test_start_values():
     K = dipolarkernel(t,r,lam,Bmodel)
     V = K@P
 
-    fit = fitsignal(V,t,r,'P',bg_exp,ex_4pdeer,par0_bg=0.5,par0_ex=0.5,uqanalysis=False)
+    fit = fitsignal(V,t,r,'P',bg_exp,ex_4pdeer,bg_par0=0.5,ex_par0=0.5,uqanalysis=False)
 
     assert ovl(P,fit.P) > 0.95
 # ======================================================================
@@ -145,8 +145,8 @@ def test_boundaries():
     V = K@P 
 
     fit = fitsignal(V,t,r,'P',bg_exp,ex_4pdeer, uqanalysis=False,
-                    par0_bg=0.4, lb_bg=0.2, ub_bg=0.5,
-                    par0_ex=0.4, lb_ex=0.2, ub_ex=0.5)
+                    bg_par0=0.4, bg_lb=0.2, bg_ub=0.5,
+                    ex_par0=0.4, ex_lb=0.2, ex_ub=0.5)
 
     assert ovl(P,fit.P) > 0.95
 # ======================================================================

--- a/test/test_fitsignal.py
+++ b/test/test_fitsignal.py
@@ -126,8 +126,7 @@ def test_start_values():
     K = dipolarkernel(t,r,lam,Bmodel)
     V = K@P
 
-    par0 = [[],0.5,0.5]
-    fit = fitsignal(V,t,r,'P',bg_exp,ex_4pdeer,par0,uqanalysis=False)
+    fit = fitsignal(V,t,r,'P',bg_exp,ex_4pdeer,par0_bg=0.5,par0_ex=0.5,uqanalysis=False)
 
     assert ovl(P,fit.P) > 0.95
 # ======================================================================
@@ -145,14 +144,12 @@ def test_boundaries():
     K = dipolarkernel(t,r,lam,Bmodel)
     V = K@P 
 
-    par0 = [[],0.4,0.4]
-    lb = [[],0.2,0.2]
-    ub = [[],0.5,0.5]
-    fit = fitsignal(V,t,r,'P',bg_exp,ex_4pdeer,par0,lb,ub,uqanalysis=False)
+    fit = fitsignal(V,t,r,'P',bg_exp,ex_4pdeer, uqanalysis=False,
+                    par0_bg=0.4, lb_bg=0.2, ub_bg=0.5,
+                    par0_ex=0.4, lb_ex=0.2, ub_ex=0.5)
 
     assert ovl(P,fit.P) > 0.95
 # ======================================================================
-
 
 def test_global_4pdeer():
 # ======================================================================


### PR DESCRIPTION
Resolves #40 

As discussed in #40 this PR introduces a simplified interface for the definition of the initial values and boundary constraints of the different model parameters subsets. This new interface align well with the principles in [PEP20](https://www.python.org/dev/peps/pep-0020/#references).

Previous keywords: 
``par0, lb, ub``
New keywords:
``par0_dd, par0_bg, par0_ex, lb_dd, lb_bg, lb_ex, ub_dd, ub_bg, ub_ex``
