### PR TITLE
Add RIDME experiment models

### DIFF
--- a/.github/workflows/docs_PR.yml
+++ b/.github/workflows/docs_PR.yml
@@ -33,6 +33,7 @@ jobs:
            python -m pip install numpydoc
            python -m pip install sphinx-gallery
            python -m pip install sphinxcontrib-httpdomain
+           python -m pip install sphinxcontrib-ghcontributors
            python -m pip install m2r2
            python -m pip install sphinx==1.8.4
            sudo apt install texlive-extra-utils

--- a/deerlab/ex_models.py
+++ b/deerlab/ex_models.py
@@ -280,3 +280,293 @@ def ex_7pdeer(param=None):
     
     return pathways
 # ===================================================================
+
+
+def ex_ridme1(param=None):
+# ===================================================================
+    r"""
+    RIDME experiment model (spin S=1/2)
+    ===================================
+ 
+    If called without arguments, returns an ``info`` dictionary of model parameters and boundaries::
+
+        info = ex_ridme1()
+
+
+    Otherwise the function returns to calculated experiment dipolar pathways::
+    
+        pathways = ex_ridme1(param)
+ 
+ 
+    Parameters
+    ----------
+    param : array_like
+        List of model parameter values.
+
+    Returns
+    -------
+    info : dict
+        Dictionary containing the built-in information of the model:
+        
+        * ``info['Parameters']`` - string list of parameter names
+        * ``info['Units']`` - string list of metric units of parameters
+        * ``info['Start']`` - list of values used as start values during optimization 
+        * ``info['Lower']`` - list of values used as lower bounds during optimization 
+        * ``info['Upper']`` - list of values used as upper bounds during optimization 
+    pathways : ndarray
+        Dipolar pathways of the experiment
+ 
+    Model parameters:
+    -------------------
+
+     ---------------------------------------------------------------------------
+      Parameter                                Units   Lower    Upper    Start
+     ---------------------------------------------------------------------------
+      Amplitude of unmodulated contribution              0       1        0.3
+      Amplitude of 1st harmonic pathway                  0       1        0.5
+     ---------------------------------------------------------------------------
+    """  
+    if param is None:
+        info = dict(
+            Parameters = ['Amplitude of unmodulated contribution','Amplitude of 1st modulated pathway'],
+            Units = ['',''],
+            Start = np.asarray([0.3, 0.5]),
+            Lower = np.asarray([0, 0]),
+            Upper = np.asarray([1, 1])
+        )
+        return info
+    param = _parsargs(param,npar=2)
+
+    # Dipolar pathways
+    lam = param.copy()
+    pathways = [[] for _ in lam]
+    pathways[0] = [lam[0]]
+    pathways[1] = [lam[1], 0, 1]
+    
+    return pathways
+# ===================================================================
+
+
+def ex_ridme3(param=None):
+# ===================================================================
+    r"""
+    RIDME experiment model (spin S=3/2)
+    ====================================
+ 
+    If called without arguments, returns an ``info`` dictionary of model parameters and boundaries::
+
+        info = ex_ridme3()
+
+
+    Otherwise the function returns to calculated experiment dipolar pathways::
+    
+        pathways = ex_ridme3(param)
+ 
+ 
+    Parameters
+    ----------
+    param : array_like
+        List of model parameter values.
+
+    Returns
+    -------
+    info : dict
+        Dictionary containing the built-in information of the model:
+        
+        * ``info['Parameters']`` - string list of parameter names
+        * ``info['Units']`` - string list of metric units of parameters
+        * ``info['Start']`` - list of values used as start values during optimization 
+        * ``info['Lower']`` - list of values used as lower bounds during optimization 
+        * ``info['Upper']`` - list of values used as upper bounds during optimization 
+    pathways : ndarray
+        Dipolar pathways of the experiment
+ 
+    Model parameters:
+    -------------------
+
+     ---------------------------------------------------------------------------
+      Parameter                                Units   Lower    Upper    Start
+     ---------------------------------------------------------------------------
+      Amplitude of unmodulated contribution              0       1        0.3
+      Amplitude of 1st harmonic pathway                  0       1        0.5
+      Amplitude of 2nd harmonic pathway                  0       1        0.3
+      Amplitude of 3rd harmonic pathway                  0       1        0.2
+     ---------------------------------------------------------------------------
+    """  
+    if param is None:
+        info = dict(
+            Parameters = ['Amplitude of unmodulated contribution','Amplitude of 1st harmonic pathway',
+                          'Amplitude of 2nd harmonic pathway','Amplitude of 3rd harmonic pathway'],
+            Units = ['','','',''],
+            Start = np.asarray([0.3, 0.5, 0.3, 0.2]),
+            Lower = np.asarray([0, 0, 0, 0]),
+            Upper = np.asarray([1, 1, 1, 1])
+        )
+        return info
+    param = _parsargs(param,npar=4)
+
+    # Dipolar pathways
+    lam = param.copy()
+    pathways = [[] for _ in lam]
+    pathways[0] = [lam[0]]
+    pathways[1] = [lam[1], 0, 1]
+    pathways[2] = [lam[2], 0, 2]
+    pathways[3] = [lam[3], 0, 3]
+    
+    return pathways
+# ===================================================================
+
+
+def ex_ridme5(param=None):
+# ===================================================================
+    r"""
+    RIDME experiment model (spin S=5/2)
+    ====================================
+ 
+    If called without arguments, returns an ``info`` dictionary of model parameters and boundaries::
+
+        info = ex_ridme5()
+
+
+    Otherwise the function returns to calculated experiment dipolar pathways::
+    
+        pathways = ex_ridme5(param)
+ 
+ 
+    Parameters
+    ----------
+    param : array_like
+        List of model parameter values.
+
+    Returns
+    -------
+    info : dict
+        Dictionary containing the built-in information of the model:
+        
+        * ``info['Parameters']`` - string list of parameter names
+        * ``info['Units']`` - string list of metric units of parameters
+        * ``info['Start']`` - list of values used as start values during optimization 
+        * ``info['Lower']`` - list of values used as lower bounds during optimization 
+        * ``info['Upper']`` - list of values used as upper bounds during optimization 
+    pathways : ndarray
+        Dipolar pathways of the experiment
+ 
+    Model parameters:
+    -------------------
+
+     ---------------------------------------------------------------------------
+      Parameter                                Units   Lower    Upper    Start
+     ---------------------------------------------------------------------------
+      Amplitude of unmodulated component                 0       1        0.3
+      Amplitude of 1st harmonic pathway                  0       1        0.5
+      Amplitude of 2nd harmonic pathway                  0       1        0.3
+      Amplitude of 3rd harmonic pathway                  0       1        0.2 
+      Amplitude of 4th harmonic pathway                  0       1        0.1 
+      Amplitude of 5th harmonic pathway                  0       1        0.05 
+     ---------------------------------------------------------------------------
+    """  
+    if param is None:
+        info = dict(
+            Parameters = ['Amplitude of unmodulated contribution','Amplitude of 1st harmonic pathway',
+                          'Amplitude of 2nd harmonic pathway','Amplitude of 3rd harmonic pathway',
+                          'Amplitude of 4th harmonic pathway','Amplitude of 5th harmonic pathway'],
+            Units = ['','','','','',''],
+            Start = np.asarray([0.3, 0.5, 0.3, 0.2,0.1,0.05]),
+            Lower = np.asarray([0, 0, 0, 0, 0, 0]),
+            Upper = np.asarray([1, 1, 1, 1, 1, 1])
+        )
+        return info
+    param = _parsargs(param,npar=6)
+
+    # Dipolar pathways
+    lam = param.copy()
+    pathways = [[] for _ in lam]
+    pathways[0] = [lam[0]]
+    pathways[1] = [lam[1], 0, 1]
+    pathways[2] = [lam[2], 0, 2]
+    pathways[3] = [lam[3], 0, 3]
+    pathways[4] = [lam[4], 0, 4]
+    pathways[5] = [lam[5], 0, 5]
+
+    return pathways
+# ===================================================================
+
+
+def ex_ridme7(param=None):
+# ===================================================================
+    r"""
+    RIDME experiment model (spin S=7/2)
+    ====================================
+ 
+    If called without arguments, returns an ``info`` dictionary of model parameters and boundaries::
+
+        info = ex_ridme7()
+
+
+    Otherwise the function returns to calculated experiment dipolar pathways::
+    
+        pathways = ex_ridme7(param)
+ 
+ 
+    Parameters
+    ----------
+    param : array_like
+        List of model parameter values.
+
+    Returns
+    -------
+    info : dict
+        Dictionary containing the built-in information of the model:
+        
+        * ``info['Parameters']`` - string list of parameter names
+        * ``info['Units']`` - string list of metric units of parameters
+        * ``info['Start']`` - list of values used as start values during optimization 
+        * ``info['Lower']`` - list of values used as lower bounds during optimization 
+        * ``info['Upper']`` - list of values used as upper bounds during optimization 
+    pathways : ndarray
+        Dipolar pathways of the experiment
+ 
+    Model parameters:
+    -------------------
+
+     ---------------------------------------------------------------------------
+      Parameter                                Units   Lower    Upper    Start
+     ---------------------------------------------------------------------------
+      Amplitude of unmodulated component                 0       1        0.3
+      Amplitude of 1st harmonic pathway                  0       1        0.5
+      Amplitude of 2nd harmonic pathway                  0       1        0.3
+      Amplitude of 3rd harmonic pathway                  0       1        0.2 
+      Amplitude of 4th harmonic pathway                  0       1        0.1 
+      Amplitude of 5th harmonic pathway                  0       1        0.05 
+      Amplitude of 6th harmonic pathway                  0       1        0.02 
+      Amplitude of 7th harmonic pathway                  0       1        0.01 
+     ---------------------------------------------------------------------------
+    """  
+    if param is None:
+        info = dict(
+            Parameters = ['Amplitude of unmodulated contribution','Amplitude of 1st harmonic pathway',
+                          'Amplitude of 2nd harmonic pathway','Amplitude of 3rd harmonic pathway',
+                          'Amplitude of 4th harmonic pathway','Amplitude of 5th harmonic pathway',
+                          'Amplitude of 6th harmonic pathway','Amplitude of 7th harmonic pathway'],
+            Units = ['','','','','','','',''],
+            Start = np.asarray([0.3, 0.5, 0.3, 0.2,0.1,0.05,0.02,0.01]),
+            Lower = np.asarray([0, 0, 0, 0, 0, 0, 0, 0]),
+            Upper = np.asarray([1, 1, 1, 1, 1, 1, 1, 1])
+        )
+        return info
+    param = _parsargs(param,npar=8)
+
+    # Dipolar pathways
+    lam = param.copy()
+    pathways = [[] for _ in lam]
+    pathways[0] = [lam[0]]
+    pathways[1] = [lam[1], 0, 1]
+    pathways[2] = [lam[2], 0, 2]
+    pathways[3] = [lam[3], 0, 3]
+    pathways[4] = [lam[4], 0, 4]
+    pathways[5] = [lam[5], 0, 5]
+    pathways[6] = [lam[6], 0, 6]
+    pathways[7] = [lam[7], 0, 7]
+
+    return pathways
+# ===================================================================

--- a/docsrc/source/models/ex_ridme1.rst
+++ b/docsrc/source/models/ex_ridme1.rst
@@ -1,0 +1,58 @@
+.. highlight:: python
+.. _ex_ridme1:
+
+
+***********************
+:mod:`ex_ridme1`
+***********************
+
+.. autofunction:: deerlab.ex_models.ex_ridme1
+
+
+Model
+=========================================
+
+This experiment model has one harmonic pathway and an unmodulated contribution. The kernel is 
+
+.. math::
+   K(t,r) =
+   [\Lambda_0 + \lambda_1 K_0(t,r)]B(t)
+
+
+============== =================== ============= ============ ============ ================================================
+ Variable        Symbol            Start Values     Lower        Upper                Description
+============== =================== ============= ============ ============ ================================================
+``param[0]``   :math:`\Lambda_0`     0.5           0            1          Amplitude of unmodulated contribution
+``param[1]``   :math:`\lambda_1`     0.3           0            1          Amplitude of 1st harmonic pathway
+============== =================== ============= ============ ============ ================================================
+
+
+Example
+=========================================
+
+Example of a simulated signal using the model evaluated at the start values of its parameters:
+
+.. plot::
+
+   import deerlab as dl
+   import matplotlib.pyplot as plt 
+   import numpy as np 
+   model = dl.ex_ridme1
+   t = np.linspace(-0.5,5,400)
+   r = np.linspace(2,5,200)
+   info = dl.dd_gauss()
+   par0 = info['Start']
+   P = dl.dd_gauss(r,par0)
+   info = model()
+   par0 = info['Start']
+   paths = model(par0)
+   K = dl.dipolarkernel(t,r,paths,lambda t,lam: dl.bg_hom3d(t,80,lam))
+   V = K@P
+   plt.figure(figsize=[6,3])
+   plt.plot(t,V)
+   plt.xlabel('t [μs]',fontsize=13)
+   plt.ylabel('V(t)',fontsize=13)
+   plt.grid(alpha=0.4)
+   plt.tick_params(labelsize=12)
+   plt.tick_params(labelsize=12)
+   plt.tight_layout()

--- a/docsrc/source/models/ex_ridme3.rst
+++ b/docsrc/source/models/ex_ridme3.rst
@@ -1,0 +1,60 @@
+.. highlight:: python
+.. _ex_ridme3:
+
+
+***********************
+:mod:`ex_ridme3`
+***********************
+
+.. autofunction:: deerlab.ex_models.ex_ridme3
+
+
+Model
+=========================================
+
+This experiment model has three harmonic pathways and an unmodulated contribution. The kernel is 
+
+.. math::
+   K(t,r) =
+   [\Lambda_0 + \lambda_1 K_0(t,r) + \lambda_2 K_0(2t,r) + \lambda_3 K_0(3t,r)]B(t)
+
+
+============== =================== ============= ============ ============ ================================================
+ Variable        Symbol            Start Values     Lower        Upper                Description
+============== =================== ============= ============ ============ ================================================
+``param[0]``   :math:`\Lambda_0`     0.5           0            1          Amplitude of unmodulated contribution
+``param[1]``   :math:`\lambda_1`     0.5           0            1          Amplitude of 1st harmonic pathway
+``param[2]``   :math:`\lambda_2`     0.3           0            1          Amplitude of 2nd harmonic pathway
+``param[3]``   :math:`\lambda_3`     0.2           0            1          Amplitude of 3rd harmonic pathway
+============== =================== ============= ============ ============ ================================================
+
+
+Example
+=========================================
+
+Example of a simulated signal using the model evaluated at the start values of its parameters:
+
+.. plot::
+
+   import deerlab as dl
+   import matplotlib.pyplot as plt 
+   import numpy as np 
+   model = dl.ex_ridme3
+   t = np.linspace(-0.5,5,400)
+   r = np.linspace(2,5,200)
+   info = dl.dd_gauss()
+   par0 = info['Start']
+   P = dl.dd_gauss(r,par0)
+   info = model()
+   par0 = info['Start']
+   paths = model(par0)
+   K = dl.dipolarkernel(t,r,paths,lambda t,lam: dl.bg_hom3d(t,80,lam))
+   V = K@P
+   plt.figure(figsize=[6,3])
+   plt.plot(t,V)
+   plt.xlabel('t [μs]',fontsize=13)
+   plt.ylabel('V(t)',fontsize=13)
+   plt.grid(alpha=0.4)
+   plt.tick_params(labelsize=12)
+   plt.tick_params(labelsize=12)
+   plt.tight_layout()

--- a/docsrc/source/models/ex_ridme5.rst
+++ b/docsrc/source/models/ex_ridme5.rst
@@ -1,0 +1,62 @@
+.. highlight:: python
+.. _ex_ridme5:
+
+
+***********************
+:mod:`ex_ridme5`
+***********************
+
+.. autofunction:: deerlab.ex_models.ex_ridme5
+
+
+Model
+=========================================
+
+This experiment model has five harmonic pathways and an unmodulated contribution. The kernel is 
+
+.. math::
+   K(t,r) =
+   [\Lambda_0 + \lambda_1 K_0(t,r) + \lambda_2 K_0(2t,r) + \lambda_3 K_0(3t,r) + \lambda_4 K_0(4t,r) + \lambda_5 K_0(5t,r)]B(t)
+
+
+============== =================== ============= ============ ============ ================================================
+ Variable        Symbol            Start Values     Lower        Upper                Description
+============== =================== ============= ============ ============ ================================================
+``param[0]``   :math:`\Lambda_0`     0.5           0            1          Amplitude of unmodulated contribution
+``param[1]``   :math:`\lambda_1`     0.5           0            1          Amplitude of 1st harmonic pathway
+``param[2]``   :math:`\lambda_2`     0.3           0            1          Amplitude of 2nd harmonic pathway
+``param[3]``   :math:`\lambda_3`     0.2           0            1          Amplitude of 3rd harmonic pathway
+``param[4]``   :math:`\lambda_4`     0.1           0            1          Amplitude of 4th harmonic pathway
+``param[5]``   :math:`\lambda_5`     0.05          0            1          Amplitude of 5th harmonic pathway
+============== =================== ============= ============ ============ ================================================
+
+
+Example
+=========================================
+
+Example of a simulated signal using the model evaluated at the start values of its parameters:
+
+.. plot::
+
+   import deerlab as dl
+   import matplotlib.pyplot as plt 
+   import numpy as np 
+   model = dl.ex_ridme5
+   t = np.linspace(-0.5,5,400)
+   r = np.linspace(2,5,200)
+   info = dl.dd_gauss()
+   par0 = info['Start']
+   P = dl.dd_gauss(r,par0)
+   info = model()
+   par0 = info['Start']
+   paths = model(par0)
+   K = dl.dipolarkernel(t,r,paths,lambda t,lam: dl.bg_hom3d(t,80,lam))
+   V = K@P
+   plt.figure(figsize=[6,3])
+   plt.plot(t,V)
+   plt.xlabel('t [μs]',fontsize=13)
+   plt.ylabel('V(t)',fontsize=13)
+   plt.grid(alpha=0.4)
+   plt.tick_params(labelsize=12)
+   plt.tick_params(labelsize=12)
+   plt.tight_layout()

--- a/docsrc/source/models/ex_ridme7.rst
+++ b/docsrc/source/models/ex_ridme7.rst
@@ -1,0 +1,64 @@
+.. highlight:: python
+.. _ex_ridme7:
+
+
+***********************
+:mod:`ex_ridme7`
+***********************
+
+.. autofunction:: deerlab.ex_models.ex_ridme7
+
+
+Model
+=========================================
+
+This experiment model has seven harmonic pathways and an unmodulated contribution. The kernel is 
+
+.. math::
+   K(t,r) =
+   [\Lambda_0 + \lambda_1 K_0(t,r) + \lambda_2 K_0(2t,r) + \lambda_3 K_0(3t,r) + \lambda_4 K_0(4t,r) + \lambda_5 K_0(5t,r) + \lambda_6 K_0(6t,r) + \lambda_7 K_0(7t,r)]B(t)
+
+
+============== =================== ============= ============ ============ ================================================
+ Variable        Symbol            Start Values     Lower        Upper                Description
+============== =================== ============= ============ ============ ================================================
+``param[0]``   :math:`\Lambda_0`     0.5           0            1          Amplitude of unmodulated contribution
+``param[1]``   :math:`\lambda_1`     0.5           0            1          Amplitude of 1st harmonic pathway
+``param[2]``   :math:`\lambda_2`     0.3           0            1          Amplitude of 2nd harmonic pathway
+``param[3]``   :math:`\lambda_3`     0.2           0            1          Amplitude of 3rd harmonic pathway
+``param[4]``   :math:`\lambda_4`     0.1           0            1          Amplitude of 4th harmonic pathway
+``param[5]``   :math:`\lambda_5`     0.05          0            1          Amplitude of 5th harmonic pathway
+``param[6]``   :math:`\lambda_6`     0.02          0            1          Amplitude of 6th harmonic pathway
+``param[7]``   :math:`\lambda_7`     0.01          0            1          Amplitude of 7th harmonic pathway
+============== =================== ============= ============ ============ ================================================
+
+
+Example
+=========================================
+
+Example of a simulated signal using the model evaluated at the start values of its parameters:
+
+.. plot::
+
+   import deerlab as dl
+   import matplotlib.pyplot as plt 
+   import numpy as np 
+   model = dl.ex_ridme7
+   t = np.linspace(-0.5,5,400)
+   r = np.linspace(2,5,200)
+   info = dl.dd_gauss()
+   par0 = info['Start']
+   P = dl.dd_gauss(r,par0)
+   info = model()
+   par0 = info['Start']
+   paths = model(par0)
+   K = dl.dipolarkernel(t,r,paths,lambda t,lam: dl.bg_hom3d(t,80,lam))
+   V = K@P
+   plt.figure(figsize=[6,3])
+   plt.plot(t,V)
+   plt.xlabel('t [μs]',fontsize=13)
+   plt.ylabel('V(t)',fontsize=13)
+   plt.grid(alpha=0.4)
+   plt.tick_params(labelsize=12)
+   plt.tick_params(labelsize=12)
+   plt.tight_layout()

--- a/docsrc/source/modelsref.rst
+++ b/docsrc/source/modelsref.rst
@@ -138,6 +138,10 @@ Model function                               Description
 :ref:`ex_ovl4pdeer`               4-pulse DEER (including 2+1 pathway) 
 :ref:`ex_5pdeer`                  5-pulse DEER
 :ref:`ex_7pdeer`                  7-pulse DEER
+:ref:`ex_ridme1`                  RIDME with one harmonic pathway (spin S=1/2)
+:ref:`ex_ridme3`                  RIDME with three harmonic pathways (spin S=3/2)
+:ref:`ex_ridme5`                  RIDME with five harmonic pathways (spin S=5/2)
+:ref:`ex_ridme7`                  RIDME with seven harmonic pathways (spin S=7/2)
 ============================== =============================================================================
 
 

--- a/examples/plot_bootstrapped_parameter_distributions.py
+++ b/examples/plot_bootstrapped_parameter_distributions.py
@@ -37,13 +37,11 @@ def fitroutine(V):
     ex_lb   = [ 0,   0,   0,  max(t)/2-1] # lower bounds
     ex_ub   = [10,  10,  10,  max(t)/2+1] # upper bounds
     ex_par0 = [0.5, 0.5, 0.5, max(t)/2  ] # start values
-    ub = [[],[],ex_ub]
-    lb = [[],[],ex_lb]
-    par0 = [[],[],ex_par0]
+
     # When running the fit, since we are only interested in the parameters we'll ignore
     # the rest (otherwise the ``Bfit``,``Pfit``,etc. could be bootstrapped as well) 
     # We need the Vfit to pass it to bootan as well, so we'll request that one too.
-    fit = dl.fitsignal(V,t,r,'P',dl.bg_hom3d,dl.ex_5pdeer,par0,lb,ub,uqanalysis=False)
+    fit = dl.fitsignal(V,t,r,'P',dl.bg_hom3d,dl.ex_5pdeer,ex_par0=ex_par0,ex_lb=ex_lb,ex_ub=ex_ub,uqanalysis=False)
     Vfit = fit.V
     exparam = fit.exparam
     exparam[0:3] /=sum(exparam[0:3])

--- a/examples/plot_fitting_5pdeer.py
+++ b/examples/plot_fitting_5pdeer.py
@@ -47,5 +47,5 @@ ex_par0 = [0.5, 0.5, 0.5, max(t)/2  ] # start values
 # Run the fit with a 5-pulse DEER signal model
 
 # %%
-fit = dl.fitsignal(Vexp,t,r,'P',dl.bg_hom3d,dl.ex_5pdeer,par0_ex=ex_par0,lb_ex=ex_lb,ub_ex=ex_ub)
+fit = dl.fitsignal(Vexp,t,r,'P',dl.bg_hom3d,dl.ex_5pdeer,ex_par0=ex_par0,ex_lb=ex_lb,ex_ub=ex_ub)
 fit.plot()

--- a/test/test_fitsignal.py
+++ b/test/test_fitsignal.py
@@ -5,6 +5,7 @@ from deerlab import dipolarkernel, whitegaussnoise, fitsignal
 from deerlab.dd_models import dd_gauss
 from deerlab.bg_models import bg_exp, bg_hom3d
 from deerlab.ex_models import ex_4pdeer, ex_5pdeer, ex_7pdeer, ex_ovl4pdeer
+import deerlab as dl
 from deerlab.utils import ovl
 
 
@@ -54,6 +55,27 @@ def test_ovl4pdeer():
     "Check that the fit of a 4-pulse DEER signal is correct"
         
     assert_experiment_model(ex_ovl4pdeer)
+# ======================================================================
+
+def test_ridme1():
+# ======================================================================
+    "Check that the fit of a S=1/2 RIDME signal is correct"
+        
+    assert_experiment_model(dl.ex_ridme1)
+# ======================================================================
+
+def test_ridme3():
+# ======================================================================
+    "Check that the fit of a S=3/2 RIDME signal is correct"
+        
+    assert_experiment_model(dl.ex_ridme3)
+# ======================================================================
+
+def test_ridme5():
+# ======================================================================
+    "Check that the fit of a S=5/2 RIDME signal is correct"
+        
+    assert_experiment_model(dl.ex_ridme5)
 # ======================================================================
 
 def test_dipevo_function():


### PR DESCRIPTION
This PR introduces a new set of `ex_` models to simplify the interface when dealing with RIDME experiments with multiple harmonic pathways. To keep nomenclature consistent, the pathway amplitudes are referred to like that instead of overtone coefficients.

While using these models directly to fit data will results in non-unique results in most cases (known issue), for now these will be helpful for simulation and method development.

New additions: 
- `ex_ridme1` to `ex_ridme7` generate the pathways for RIDME experiments with one to seven harmonic pathways, respectively.
- Reference pages added to the documentation