### PR TITLE
Fix behaviour of deerload with 2D-datasets 

### DIFF
--- a/deerlab/deerload.py
+++ b/deerlab/deerload.py
@@ -225,7 +225,6 @@ def deerload(fullbasename, plot=False, full_output=False, *args,**kwargs):
             # Remove nan values to ensure proper length of abscissa
             abscissas.append(absc[~np.isnan(absc)])
     # If 1D-dataset, return array instead of single-element list
-    print(len(abscissas))
     if len(abscissas)==1:
         abscissas = abscissas[0]
 

--- a/deerlab/deerload.py
+++ b/deerlab/deerload.py
@@ -186,7 +186,6 @@ def deerload(fullbasename, plot=False, full_output=False, *args,**kwargs):
             data = np.copy(data)
         elif parDESC['IKKF'] == 'CPLX':
             dt_new = np.dtype('complex')
-            data = np.full((2*nx*ny*nz,1),np.nan)
             with open(filename_dta,'rb') as fp:
                 data = np.frombuffer(fp.read(),dtype=dt_spc)
                 # Check if there is multiple harmonics (High field ESR quadrature detection)

--- a/deerlab/deerload.py
+++ b/deerlab/deerload.py
@@ -63,7 +63,6 @@ def deerload(fullbasename, plot=False, full_output=False, *args,**kwargs):
     parameters = read_description_file(filename_dsc)
     parDESC = parameters["DESC"]
     parSPL = parameters["SPL"]
-    print( int(parDESC['XPTS']))
     # XPTS, YPTS, ZPTS specify the number of data points along x, y and z.
     if 'XPTS' in parDESC:
         nx = int(parDESC['XPTS'])

--- a/deerlab/deerload.py
+++ b/deerlab/deerload.py
@@ -179,7 +179,7 @@ def deerload(fullbasename, plot=False, full_output=False, *args,**kwargs):
         if parDESC['IKKF'] == 'REAL':
             data = np.full((nx,ny,nz),np.nan) 
             with open(filename_dta,'rb') as fp:
-                 data = np.frombuffer(fp.read(),dtype=dt_spc).reshape(nx,ny,nz)
+                 data = np.frombuffer(fp.read(),dtype=dt_spc)
             data = np.copy(data)
         elif parDESC['IKKF'] == 'CPLX':
             dt_new = np.dtype('complex')
@@ -198,17 +198,17 @@ def deerload(fullbasename, plot=False, full_output=False, *args,**kwargs):
 
             # copy the data to a writable numpy array
             data = np.copy(data.astype(dtype=dt_data).view(dtype=dt_new))
-
-            # Split 1D-array according to XPTS/YPTS/ZPTS into 3D-array
-            data = np.array_split(data,nz)
-            data = np.array(data).T
-            data = np.array_split(data,ny)
-            data = np.array(data).T
         else:
             raise ValueError("Unknown value for keyword IKKF in .DSC file!")
     else:
         warn("Keyword IKKF not found in .DSC file! Assuming IKKF=REAL.")
     
+        # Split 1D-array according to XPTS/YPTS/ZPTS into 3D-array
+        data = np.array_split(data,nz)
+        data = np.array(data).T
+        data = np.array_split(data,ny)
+        data = np.array(data).T
+
     # Ensue proper numpy formatting
     data = np.atleast_1d(data)
     data = np.squeeze(data)

--- a/deerlab/deerload.py
+++ b/deerlab/deerload.py
@@ -204,10 +204,10 @@ def deerload(fullbasename, plot=False, full_output=False, *args,**kwargs):
         warn("Keyword IKKF not found in .DSC file! Assuming IKKF=REAL.")
     
     # Split 1D-array into 3D-array according to XPTS/YPTS/ZPTS 
-        data = np.array_split(data,nz)
-        data = np.array(data).T
-        data = np.array_split(data,ny)
-        data = np.array(data).T
+    data = np.array_split(data,nz)
+    data = np.array(data).T
+    data = np.array_split(data,ny)
+    data = np.array(data).T
 
     # Ensue proper numpy formatting
     data = np.atleast_1d(data)
@@ -225,6 +225,10 @@ def deerload(fullbasename, plot=False, full_output=False, *args,**kwargs):
             absc /= 1e3
             # Remove nan values to ensure proper length of abscissa
             abscissas.append(absc[~np.isnan(absc)])
+    # If 1D-dataset, return array instead of single-element list
+    print(len(abscissas))
+    if len(abscissas)==1:
+        abscissas = abscissas[0]
 
     if plot:
         plt.plot(abscissa,np.real(data),abscissa,np.imag(data))

--- a/deerlab/deerload.py
+++ b/deerlab/deerload.py
@@ -63,7 +63,7 @@ def deerload(fullbasename, plot=False, full_output=False, *args,**kwargs):
     parameters = read_description_file(filename_dsc)
     parDESC = parameters["DESC"]
     parSPL = parameters["SPL"]
-    
+    print( int(parDESC['XPTS']))
     # XPTS, YPTS, ZPTS specify the number of data points along x, y and z.
     if 'XPTS' in parDESC:
         nx = int(parDESC['XPTS'])
@@ -197,16 +197,18 @@ def deerload(fullbasename, plot=False, full_output=False, *args,**kwargs):
                     ny = int(len(data)/nx/n_harmonics)
 
             # copy the data to a writable numpy array
-            data = np.copy(data.astype(dtype=dt_data).view(dtype=dt_new).reshape(nx,ny,nz))
+            data = np.copy(data.astype(dtype=dt_data).view(dtype=dt_new))
+
+            # Split 1D-array according to XPTS/YPTS/ZPTS into 3D-array
+            data = np.array_split(data,nz)
+            data = np.array(data).T
+            data = np.array_split(data,ny)
+            data = np.array(data).T
         else:
             raise ValueError("Unknown value for keyword IKKF in .DSC file!")
     else:
         warn("Keyword IKKF not found in .DSC file! Assuming IKKF=REAL.")
     
-    if nz == 1:
-        data = data.reshape(nx,ny)
-
-
     # Ensue proper numpy formatting
     data = np.atleast_1d(data)
     data = np.squeeze(data)

--- a/deerlab/deerload.py
+++ b/deerlab/deerload.py
@@ -208,7 +208,7 @@ def deerload(fullbasename, plot=False, full_output=False, *args,**kwargs):
         warn("Keyword IKKF not found in .DSC file! Assuming IKKF=REAL.")
     
     if nz == 1:
-        data = data.reshape(nx,ny)
+        data = data.reshape(ny,nx)
             
      # ns -> us converesion
     abscissa /= 1e3

--- a/deerlab/deerload.py
+++ b/deerlab/deerload.py
@@ -208,7 +208,7 @@ def deerload(fullbasename, plot=False, full_output=False, *args,**kwargs):
         warn("Keyword IKKF not found in .DSC file! Assuming IKKF=REAL.")
     
     if nz == 1:
-        data = data.reshape(ny,nx)
+        data = data.reshape(nx,ny)
             
      # ns -> us converesion
     abscissa /= 1e3

--- a/deerlab/deerload.py
+++ b/deerlab/deerload.py
@@ -203,7 +203,7 @@ def deerload(fullbasename, plot=False, full_output=False, *args,**kwargs):
     else:
         warn("Keyword IKKF not found in .DSC file! Assuming IKKF=REAL.")
     
-        # Split 1D-array according to XPTS/YPTS/ZPTS into 3D-array
+    # Split 1D-array into 3D-array according to XPTS/YPTS/ZPTS 
         data = np.array_split(data,nz)
         data = np.array(data).T
         data = np.array_split(data,ny)


### PR DESCRIPTION
The resolves the error that the data was mapped the wrong direction.
Error was found for the attached dataset and need testing for further 2d datasets.
[2D_ScanTime.zip](https://github.com/JeschkeLab/DeerLab/files/6062181/2D_ScanTime.zip)

Fixes #82 
