### PR TITLE
Remove normalization conventions in dipolarkernel and dipolarbackground

### DIFF
--- a/deerlab/dipolarbackground.py
+++ b/deerlab/dipolarbackground.py
@@ -27,12 +27,6 @@ def dipolarbackground(t, pathways, Bmodel, renormalize=True, renormpaths=True):
         * Physical background models: A callable function accepting a time-axis array as first input and a pathway amplitude as a second, e.g. ``B = lambda t,lam: bg_hom3d(t,par,lam)``
         * Phenomenological background models: A callable function accepting a time-axis array as input, e.g. ``B = lambda t: bg_exp(t,par)``
 
-    renormalize : boolean, optional
-        Re-normalization of the multi-pathway background to ensure the equality ``B(t=0)==1`` is satisfied. Enabled by default.
-        
-    renormpaths: boolean, optional
-        Normalization of the pathway amplitudes such that ``Lam0 + lam1 + ... + lamN = 1``. Enabled by default.  
-
     Returns
     -------
     B : ndarray
@@ -105,13 +99,6 @@ def dipolarbackground(t, pathways, Bmodel, renormalize=True, renormpaths=True):
             # Otherwise paths are not correctly defined
             raise KeyError('The pathway #{} must be a list of two or three elements [lam, T0] or [lam, T0, n]'.format(i))
 
-    # Normalize the pathway amplitudes to unity
-    if renormpaths:
-        lamsum = Lambda0 + sum([path[0] for path in pathways])
-        Lambda0 /= lamsum
-        for i in range(len(pathways)):
-            pathways[i][0] /= lamsum 
-
     # Construction of multi-pathway background function 
     #-------------------------------------------------------------------------------
     Bnorm = 1
@@ -120,8 +107,5 @@ def dipolarbackground(t, pathways, Bmodel, renormalize=True, renormpaths=True):
         n,T0,lam = pathway
         B = B*Bmodel(n*(t-T0),lam)
         Bnorm = Bnorm*Bmodel(-T0*n,lam)
-    
-    if renormalize:
-        B = B/Bnorm
 
     return B

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -68,13 +68,7 @@ def dipolarkernel(t, r, pathways = 1, B = 1, method = 'fresnel', excbandwidth = 
     
     nKnots : scalar, optional
         Number of knots for the grid of powder orientations to be used in the ``'grid'`` kernel calculation method.
-    
-    renormalize : boolean, optional
-        Re-normalization of multi-pathway kernels to ensure the equality ``K(t=0,r)==1`` is satisfied. Enabled by default.
-    
-    renormpaths: boolean, optional
-        Normalization of the pathway amplitudes such that ``Lam0 + lam1 + ... + lamN = 1``. Enabled by default. 
-    
+        
     clearcache : boolean, optional
         Clear the cached dipolar kernels at the beginning of the function. Disabled by default.
 
@@ -178,14 +172,7 @@ def dipolarkernel(t, r, pathways = 1, B = 1, method = 'fresnel', excbandwidth = 
             paths[i] = np.append(path,1) 
         elif len(path) != 3:
             # Otherwise paths are not correctly defined
-            raise KeyError('The pathway #{} must be a list of two or three elements [lam, T0] or [lam, T0, n]'.format(i))
-
-    # Normalize the pathway amplitudes to unity
-    if renormpaths:
-        lamsum = Lambda0 + sum([path[0] for path in paths])
-        Lambda0 /= lamsum
-        for i in range(len(paths)):
-            paths[i][0] /= lamsum 
+            raise KeyError('The pathway #{} must be a list of two or three elements [lam, T0] or [lam, T0, n]'.format(i)) 
 
     # Define kernel matrix auxiliary function
     kernelmatrix = lambda t: calckernelmatrix(t,r,method,excbandwidth,nKnots,g)
@@ -195,14 +182,6 @@ def dipolarkernel(t, r, pathways = 1, B = 1, method = 'fresnel', excbandwidth = 
     for pathway in paths:
         lam,T0,n = pathway
         K = K + lam*kernelmatrix(n*(t-T0))
-
-    # Renormalize if requested
-    if renormalize:
-        Knorm = Lambda0
-        for pathway in paths:
-            lam,T0,n = pathway
-            Knorm = Knorm + lam*kernelmatrix(-T0*n)
-        K = K/Knorm
 
     # Multiply by background
     if ismodelB:

--- a/test/test_dipolarbackground.py
+++ b/test/test_dipolarbackground.py
@@ -142,7 +142,6 @@ def test_multipath_raw():
     for p in range(len(lam)):
             Bref = Bref*Bmodel((t-T0[p]),lam[p])
             Bnorm = Bnorm*Bmodel(-T0[p],lam[p])
-    Bref = Bref/Bnorm
     
     paths = []
     paths.append(1-prob)

--- a/test/test_dipolarbackground.py
+++ b/test/test_dipolarbackground.py
@@ -105,10 +105,8 @@ def test_multipath_renorm():
 
     #Reference
     Bref = 1
-    Bnorm = 1
     for p in range(len(lam)):
             Bref = Bref*Bmodel((t-T0[p]),lam[p])
-            Bnorm = Bnorm*Bmodel(-T0[p],lam[p])
     
     paths = []
     paths.append(1-prob)
@@ -138,10 +136,8 @@ def test_multipath_raw():
 
     #Reference
     Bref = 1
-    Bnorm = 1
     for p in range(len(lam)):
             Bref = Bref*Bmodel((t-T0[p]),lam[p])
-            Bnorm = Bnorm*Bmodel(-T0[p],lam[p])
     
     paths = []
     paths.append(1-prob)

--- a/test/test_dipolarkernel.py
+++ b/test/test_dipolarkernel.py
@@ -259,11 +259,8 @@ def test_multipath_harmonics():
     K = dipolarkernel(t,r,paths, integralop=False)
 
     Kref = 1-prob
-    Krenorm = Kref
     for p in range(len(lam)):
             Kref = Kref + lam[p]*calckernelmatrix(n[p]*(t-T0[p]),r,'fresnel',[],[],[ge,ge])
-            Krenorm = Krenorm + lam[p]*calckernelmatrix(-n[p]*T0[p],r,'fresnel',[],[],[ge,ge])
-    Kref = Kref/Krenorm
     Kref = Kref
 
     assert np.max(K-Kref) < 1e-3

--- a/test/test_dipolarkernel.py
+++ b/test/test_dipolarkernel.py
@@ -191,12 +191,8 @@ def test_multipath():
     K = dipolarkernel(t,r,paths, integralop=False)
 
     Kref = 1-prob
-    Krenorm = Kref
     for p in range(len(lam)):
             Kref = Kref + lam[p]*calckernelmatrix(t-T0[p],r,'fresnel',[],[],[ge,ge])
-            Krenorm = Krenorm + lam[p]*calckernelmatrix(-T0[p],r,'fresnel',[],[],[ge,ge])
-    Kref = Kref/Krenorm
-    Kref = Kref
 
     assert np.all(abs(K-Kref) < 1e-3)
 #=======================================================================
@@ -219,19 +215,13 @@ def test_multipath_background():
 
     # Reference
     Kref = 1-prob
-    Krenorm = Kref
     for p in range(len(lam)):
             Kref = Kref + lam[p]*calckernelmatrix(t-T0[p],r,'fresnel',[],[],[ge,ge])
-            Krenorm = Krenorm + lam[p]*calckernelmatrix(-T0[p],r,'fresnel',[],[],[ge,ge])
-    Kref = Kref/Krenorm
     Kref = Kref
     
     Bref = 1
-    Bnorm = 1
     for p in range(len(lam)):
             Bref = Bref*Bmodel((t-T0[p]),lam[p])
-            Bnorm = Bnorm*Bmodel(-T0[p],lam[p])
-    Bref = Bref/Bnorm
     KBref = Kref*Bref[:,np.newaxis]
 
     paths = []
@@ -334,7 +324,6 @@ def test_excbandwidth():
         w = wdd*orientation
         D_ = D_ + np.cos(w*abs(t))*np.exp(-w**2/excitewidth**2)
     K0 = D_/nKnots
-    K0 /= K0[0]
     K0 = K0.reshape((len(t),1))
 
     assert np.max(K0-K)<1e-4
@@ -372,21 +361,6 @@ def test_r_scaling():
     assert np.max(K1 - K2) < 1e-15
 #=======================================================================
 
-def test_arbitrary_pathway_amps():
-#=======================================================================
-    """Check compatibility with arbitrary pathway amplitudes"""
-
-    t = np.linspace(0,5,201)
-    r = 2.5
-    pathway=[]
-    pathway.append([0.2])
-    pathway.append([0.8, 0])
-    pathway.append([0.5, 3])
-
-    K = dipolarkernel(t,r,pathway)
-
-    assert np.round(K[0],2) == 1
-#=======================================================================
 
 def test_integralop():
 #=======================================================================


### PR DESCRIPTION
Remove the `renormalize` and `renormpaths` keyword arguments and related functionality from the `dipolarbackground` and `dipolarkernel` functions. This would solve the issues related to #76 

