### PR TITLE
Acceleration of fitting by avoiding model call overhead

### DIFF
--- a/deerlab/dd_models.py
+++ b/deerlab/dd_models.py
@@ -99,22 +99,26 @@ def dd_gauss(*args):
       Standard deviation         nm       0.05      2.5      0.2 
      -------------------------------------------------------------
     """  
+    def model(r,p):    
+        r0 = [p[0]]
+        sigma = [p[1]]
+        a = [1.0]
+        P = _multigaussfun(r,r0,sigma,a)
+        return P
     if not args:
         info = dict(
             Parameters = ('Mean','Standard deviation'),
             Units = ('nm','nm'),
             Start = np.asarray([3.5, 0.2]),
             Lower = np.asarray([1, 0.05]),
-            Upper = np.asarray([20, 2.5])
+            Upper = np.asarray([20, 2.5]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=2)
-
-    r0 = [p[0]]
-    sigma = [p[1]]
-    a = [1.0]
-    P = _multigaussfun(r,r0,sigma,a)
-    return P
+    else: 
+        r,p = _parsargs(args,npar=2)
+        P = model(r,p)
+        return P
 #=================================================================
     
 
@@ -164,6 +168,13 @@ def dd_gauss2(*args):
       Amplitude of 2nd Gaussian                        0        1        0.5 
      -------------------------------------------------------------------------
     """
+    def model(r,p):    
+        r0 = [p[0], p[3]]
+        sigma = [p[1], p[4]]
+        a = [p[2], p[5]]
+        P = _multigaussfun(r,r0,sigma,a)
+
+        return P
 
     if not args:
         info = dict(
@@ -172,17 +183,14 @@ def dd_gauss2(*args):
             Units = ('nm','nm','','nm','nm',''),
             Start = np.asarray([2.5, 0.2, 0.5, 3.5, 0.2, 0.5]),
             Lower = np.asarray([1, 0.05, 0, 1, 0.05, 0]),
-            Upper = np.asarray([20, 2.5, 1, 20, 2.5, 1])
+            Upper = np.asarray([20, 2.5, 1, 20, 2.5, 1]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=6)
-
-    r0 = [p[0], p[3]]
-    sigma = [p[1], p[4]]
-    a = [p[2], p[5]]
-    P = _multigaussfun(r,r0,sigma,a)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=6)
+        P = model(r,p)
+        return P
 #=================================================================
     
 
@@ -238,6 +246,13 @@ def dd_gauss3(*args):
       Amplitude of 3rd Gaussian                       0        1        0.3 
      -------------------------------------------------------------------------
     """
+    def model(r,p):    
+        r0 = [p[0], p[3], p[6]]
+        sigma = [p[1], p[4], p[7]]
+        a = [p[2], p[5], p[8]]
+        P = _multigaussfun(r,r0,sigma,a)
+
+        return P
 
     if not args:
         info = dict(
@@ -247,17 +262,14 @@ def dd_gauss3(*args):
             Units = ('nm','nm','','nm','nm','','nm','nm',''),
             Start = np.asarray([2.5, 0.2, 0.3, 3.5, 0.2, 0.3, 5, 0.2, 0.3]),
             Lower = np.asarray([1, 0.05, 0, 1, 0.05, 0, 1, 0.05, 0]),
-            Upper = np.asarray([20, 2.5, 1, 20, 2.5, 1,  20, 2.5, 1])
+            Upper = np.asarray([20, 2.5, 1, 20, 2.5, 1,  20, 2.5, 1]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=9)
-
-    r0 = [p[0], p[3], p[6]]
-    sigma = [p[1], p[4], p[7]]
-    a = [p[2], p[5], p[8]]
-    P = _multigaussfun(r,r0,sigma,a)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=9)
+        P = model(r,p)
+        return P
 #=================================================================
 
 def dd_gengauss(*args):    
@@ -305,26 +317,31 @@ def dd_gengauss(*args):
       Kurtosis             0.25    15       5 
      --------------------------------------------
     """  
+    def model(r,p):    
+        # Compute the model distance distribution
+        r0 = p[0]
+        sigma = p[1]
+        beta = p[2]
+        x = abs(r-r0)/sigma
+        P = beta/(2*sigma*spc.gamma(1/beta))*np.exp(-x**beta)
+        P = _normalize(r,P)
+
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Mean','Spread','Kurtosis'),
             Units = ('nm','nm',''),
             Start = np.asarray([3.5, 0.5,0.5]),
             Lower = np.asarray([1, 0.05, 0.25]),
-            Upper = np.asarray([20, 5, 15])
+            Upper = np.asarray([20, 5, 15]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=3)
-    
-    # Compute the model distance distribution
-    r0 = p[0]
-    sigma = p[1]
-    beta = p[2]
-    x = abs(r-r0)/sigma
-    P = beta/(2*sigma*spc.gamma(1/beta))*np.exp(-x**beta)
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=3)
+        P = model(r,p)
+        return P
 #=================================================================
     
 
@@ -374,26 +391,31 @@ def dd_skewgauss(*args):
       Skewness             -25     25      5 
      --------------------------------------------
     """  
+    def model(r,p):    
+        # Compute the model distance distribution
+        r0 = p[0]
+        sigma = p[1]
+        alpha = p[2]
+        x = (r-r0)/sigma/np.sqrt(2)
+        P = 1/np.sqrt(2*np.pi)*np.exp(-x**2)*(1 + spc.erf(alpha*x))
+        P = _normalize(r,P)
+
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Center','Spread','Kurtosis'),
             Units = ('nm','nm',''),
             Start = np.asarray([3.5, 0.2, 5]),
             Lower = np.asarray([1, 0.05, -25]),
-            Upper = np.asarray([20, 5, 25])
+            Upper = np.asarray([20, 5, 25]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=3)
-    
-    # Compute the model distance distribution
-    r0 = p[0]
-    sigma = p[1]
-    alpha = p[2]
-    x = (r-r0)/sigma/np.sqrt(2)
-    P = 1/np.sqrt(2*np.pi)*np.exp(-x**2)*(1 + spc.erf(alpha*x))
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=3)
+        P = model(r,p)
+        return P
 #=================================================================
 
 
@@ -442,22 +464,27 @@ def dd_rice(*args):
       Spread         nm       0.1       5        0.7 
      ------------------------------------------------
     """  
+    def model(r,p):    
+        nu = [p[0]]
+        sig = [p[1]]
+        a = [1.0]
+        P = _multirice3dfun(r,nu,sig,a)
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Location','Spread'),
             Units = ('nm','nm'),
             Start = np.asarray([3.5, 0.7]),
             Lower = np.asarray([1, 0.1]),
-            Upper = np.asarray([10, 5])
+            Upper = np.asarray([10, 5]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=2)
-
-    nu = [p[0]]
-    sig = [p[1]]
-    a = [1.0]
-    P = _multirice3dfun(r,nu,sig,a)
-    return P
+    else: 
+        r,p = _parsargs(args,npar=2)
+        P = model(r,p)
+        return P
 #=================================================================
     
 
@@ -510,6 +537,13 @@ def dd_rice2(*args):
       Amplitude of 2nd Rician                 0        1        0.5 
      --------------------------------------------------------------
     """
+    def model(r,p):    
+        nu = [p[0], p[3]]
+        sig = [p[1], p[4]]
+        a = [p[2], p[5]]
+        P = _multirice3dfun(r,nu,sig,a)
+
+        return P
 
     if not args:
         info = dict(
@@ -518,17 +552,14 @@ def dd_rice2(*args):
             Units = ('nm','nm','','nm','nm',''),
             Start = np.asarray([2.5, 0.7, 0.5, 4.0, 0.7, 0.5]),
             Lower = np.asarray([1, 0.1, 0, 1, 0.1, 0]),
-            Upper = np.asarray([10, 5, 1, 10, 5, 1])
+            Upper = np.asarray([10, 5, 1, 10, 5, 1]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=6)
-
-    nu = [p[0], p[3]]
-    sig = [p[1], p[4]]
-    a = [p[2], p[5]]
-    P = _multirice3dfun(r,nu,sig,a)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=6)
+        P = model(r,p)
+        return P
 #=================================================================
     
 
@@ -583,6 +614,13 @@ def dd_rice3(*args):
       Amplitude of 3rd Rician               0        1        0.3 
      --------------------------------------------------------------
     """
+    def model(r,p):    
+        nu = [p[0], p[3], p[6]]
+        sig = [p[1], p[4], p[7]]
+        a = [p[2], p[5], p[8]]
+        P = _multirice3dfun(r,nu,sig,a)
+
+        return P
 
     if not args:
         info = dict(
@@ -592,17 +630,14 @@ def dd_rice3(*args):
             Units = ('nm','nm','','nm','nm','','nm','nm',''),
             Start = np.asarray([2.5, 0.7, 0.3, 3.5, 0.7, 0.3, 5, 0.7, 0.3]),
             Lower = np.asarray([1, 0.1, 0, 1, 0.1, 0, 1, 0.1, 0]),
-            Upper = np.asarray([10, 5, 1, 10, 5, 1,  10, 5, 1])
+            Upper = np.asarray([10, 5, 1, 10, 5, 1,  10, 5, 1]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=9)
-
-    nu = [p[0], p[3], p[6]]
-    sig = [p[1], p[4], p[7]]
-    a = [p[2], p[5], p[8]]
-    P = _multirice3dfun(r,nu,sig,a)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=9)
+        P = model(r,p)
+        return P
 #=================================================================
 
 def dd_randcoil(*args):    
@@ -651,29 +686,34 @@ def dd_randcoil(*args):
       Scaling exponent             0.33    1         0.602
      ------------------------------------------------------
     """  
+    def model(r,p):    
+        N  = p[0]  # number of residues
+        nu = p[1] # scaling exponent
+        R0 = p[2] # residue length
+
+        rsq = 6*(R0*N**nu)**2 # mean square end-to-end distance from radius of gyration
+        normFact = 3/(2*np.pi*rsq)**(3/2) # normalization prefactor
+        ShellSurf = 4*np.pi*r**2 # spherical shell surface
+        Gaussian = np.exp(-3*r**2/(2*rsq))
+        P = normFact*ShellSurf*Gaussian
+        P = _normalize(r,P)
+
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
             Units = ('','nm',''),
             Start = np.asarray([50,   0.2, 0.602]),
             Lower = np.asarray([2,    0.1, 0.33 ]),
-            Upper = np.asarray([1000, 0.4, 1    ])
+            Upper = np.asarray([1000, 0.4, 1    ]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=3)
-    
-    N  = p[0]  # number of residues
-    nu = p[1] # scaling exponent
-    R0 = p[2] # residue length
-
-    rsq = 6*(R0*N**nu)**2 # mean square end-to-end distance from radius of gyration
-    normFact = 3/(2*np.pi*rsq)**(3/2) # normalization prefactor
-    ShellSurf = 4*np.pi*r**2 # spherical shell surface
-    Gaussian = np.exp(-3*r**2/(2*rsq))
-    P = normFact*ShellSurf*Gaussian
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=3)
+        P = model(r,p)
+        return P
 #=================================================================
 
 
@@ -722,29 +762,34 @@ def dd_circle(*args):
       Radius       nm      0.1      5      0.5 
      ----------------------------------------------
     """  
+    def model(r,p):    
+        # Compute the model distance distribution
+        r0 = p[0]
+        R = abs(p[1])
+
+        dr = r - r0
+        idx = abs(dr)<R
+
+        P = np.zeros(len(r))
+        P[idx] = 2/np.pi/R**2*np.sqrt(R**2 - dr[idx]**2)
+        P = _normalize(r,P)
+
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
             Units = ('nm','nm'),
             Start = np.asarray([3, 0.5]),
             Lower = np.asarray([1, 0.1]),
-            Upper = np.asarray([20, 5 ])
+            Upper = np.asarray([20, 5 ]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=2)
-    
-    # Compute the model distance distribution
-    r0 = p[0]
-    R = abs(p[1])
-
-    dr = r - r0
-    idx = abs(dr)<R
-
-    P = np.zeros(len(r))
-    P[idx] = 2/np.pi/R**2*np.sqrt(R**2 - dr[idx]**2)
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=2)
+        P = model(r,p)
+        return P
 #=================================================================
 
 
@@ -793,27 +838,32 @@ def dd_cos(*args):
       FWHM         nm      0.1      5      0.5 
      ----------------------------------------------
     """  
+    def model(r,p):    
+        # Compute the model distance distribution
+        r0 = p[0]
+        fwhm = p[1]
+
+        phi = (r-r0)/fwhm*np.pi
+        P = (1 + np.cos(phi))/2/fwhm
+        P[(r<(r0-fwhm)) | (r>(r0+fwhm))] = 0
+        P = _normalize(r,P)
+
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
             Units = ('nm','nm'),
             Start = np.asarray([3, 0.5]),
             Lower = np.asarray([1, 0.1]),
-            Upper = np.asarray([20, 5 ])
+            Upper = np.asarray([20, 5 ]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=2)
-    
-    # Compute the model distance distribution
-    r0 = p[0]
-    fwhm = p[1]
-
-    phi = (r-r0)/fwhm*np.pi
-    P = (1 + np.cos(phi))/2/fwhm
-    P[(r<(r0-fwhm)) | (r>(r0+fwhm))] = 0
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=2)
+        P = model(r,p)
+        return P
 #=================================================================
 
 
@@ -901,6 +951,21 @@ def dd_shell(*args):
     http://doi.org/10.1016/j.jmr.2013.01.007
 
     """  
+    def model(r,p):    
+        # Compute the model distance distribution
+        R1 = float(p[0])
+        w = float(p[1])
+        R2 = R1 + w
+
+        P = np.zeros(len(r))
+        P = R2**6*_pb(r,R2) - R1**6*_pb(r,R1) - 2*(R2**3 - R1**3)*_pbs(r,R1,R2)
+
+        P = P/(R2**3 - R1**3)**2
+
+        P = _normalize(r,P)
+
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
@@ -908,23 +973,13 @@ def dd_shell(*args):
             Lower = np.asarray([0.1, 0.1]),
             Upper = np.asarray([20,  20 ]),
             Start = np.asarray([1.5, 0.5]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=2)
-        
-    # Compute the model distance distribution
-    R1 = float(p[0])
-    w = float(p[1])
-    R2 = R1 + w
-
-    P = np.zeros(len(r))
-    P = R2**6*_pb(r,R2) - R1**6*_pb(r,R1) - 2*(R2**3 - R1**3)*_pbs(r,R1,R2)
-
-    P = P/(R2**3 - R1**3)**2
-
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=2)
+        P = model(r,p)
+        return P
 #=================================================================
 
 
@@ -976,7 +1031,19 @@ def dd_spherepoint(*args):
     See: D.R. Kattnig, D. Hinderberger, Journal of Magnetic Resonance, 230 (2013), 50-63 
     http://doi.org/10.1016/j.jmr.2013.01.007
 
-    """  
+    """ 
+    def model(r,p):    
+        # Compute the model distance distribution
+        R = float(p[0])
+        d = float(p[1])
+        P = np.zeros(len(r))
+        idx = (r >= d - R) & (r<= d + R)
+        P[idx] = 3*r[idx]*(R**2 - (d - r[idx])**2)/(4*d*R**3)
+
+        P = _normalize(r,P)
+
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
@@ -984,20 +1051,13 @@ def dd_spherepoint(*args):
             Lower = np.asarray([0.1, 0.1]),
             Upper = np.asarray([20,  20 ]),
             Start = np.asarray([1.5, 3.5]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=2)
-        
-    # Compute the model distance distribution
-    R = float(p[0])
-    d = float(p[1])
-    P = np.zeros(len(r))
-    idx = (r >= d - R) & (r<= d + R)
-    P[idx] = 3*r[idx]*(R**2 - (d - r[idx])**2)/(4*d*R**3)
-
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=2)
+        P = model(r,p)
+        return P
 #=================================================================
 
 
@@ -1048,7 +1108,18 @@ def dd_spheresurf(*args):
     See: D.R. Kattnig, D. Hinderberger, Journal of Magnetic Resonance, 230 (2013), 50-63 
     http://doi.org/10.1016/j.jmr.2013.01.007
 
-    """  
+    """ 
+    def model(r,p):    
+        # Compute the model distance distribution
+        R = float(p[0])
+        P = np.zeros(len(r))
+        idx = (r >= 0) & (r<= 2*R)
+        P[idx] = r[idx]/R**2
+
+        P = _normalize(r,P)
+
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
@@ -1056,19 +1127,13 @@ def dd_spheresurf(*args):
             Lower = np.asarray([0.1]),
             Upper = np.asarray([20]),
             Start = np.asarray([2.5]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=1)
-        
-    # Compute the model distance distribution
-    R = float(p[0])
-    P = np.zeros(len(r))
-    idx = (r >= 0) & (r<= 2*R)
-    P[idx] = r[idx]/R**2
-
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=1)
+        P = model(r,p)
+        return P
 #=================================================================
 
 
@@ -1122,6 +1187,29 @@ def dd_shellshell(*args):
     http://doi.org/10.1016/j.jmr.2013.01.007
 
     """  
+    def model(r,p):    
+        # Compute the model distance distribution
+        R1 = float(p[0])
+        w1 = float(p[1])
+        w2 = float(p[2])
+
+        R2 = R1 + w1
+        R3 = R2 + w2
+
+        delta21 = R2**3 - R1**3
+        q21 = delta21*_pbs(r,R1,R2)
+        delta31 = R3**3 - R1**3
+        q31 = delta31*_pbs(r,R1,R3)
+        delta32 = R3**3 - R2**3
+        q32 = delta32*_pbs(r,R2,R3)
+
+        P = R1**3*q21 - R1**3*q31 + R2**3*q32
+        P = P/(delta21*delta32)
+
+        P = _normalize(r,P)
+
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
@@ -1129,31 +1217,13 @@ def dd_shellshell(*args):
             Lower = np.asarray([0.1, 0.1, 0.1]),
             Upper = np.asarray([20,  20,  20 ]),
             Start = np.asarray([1.5, 0.5, 0.5]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=3)
-        
-    # Compute the model distance distribution
-    R1 = float(p[0])
-    w1 = float(p[1])
-    w2 = float(p[2])
-
-    R2 = R1 + w1
-    R3 = R2 + w2
-
-    delta21 = R2**3 - R1**3
-    q21 = delta21*_pbs(r,R1,R2)
-    delta31 = R3**3 - R1**3
-    q31 = delta31*_pbs(r,R1,R3)
-    delta32 = R3**3 - R2**3
-    q32 = delta32*_pbs(r,R2,R3)
-
-    P = R1**3*q21 - R1**3*q31 + R2**3*q32
-    P = P/(delta21*delta32)
-
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=3)
+        P = model(r,p)
+        return P
 #=================================================================
 
 
@@ -1207,6 +1277,17 @@ def dd_shellsphere(*args):
     http://doi.org/10.1016/j.jmr.2013.01.007
 
     """  
+    def model(r,p):    
+        # Compute the model distance distribution
+        R1 = float(p[0])
+        w = float(p[1])
+        R2 = R1 + w
+        P = _pbs(r,R1,R2)
+
+        P = _normalize(r,P)
+
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
@@ -1214,19 +1295,13 @@ def dd_shellsphere(*args):
             Lower = np.asarray([0.1, 0.1]),
             Upper = np.asarray([20,  20]),
             Start = np.asarray([1.5, 0.5]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=2)
-        
-    # Compute the model distance distribution
-    R1 = float(p[0])
-    w = float(p[1])
-    R2 = R1 + w
-    P = _pbs(r,R1,R2)
-
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=2)
+        P = model(r,p)
+        return P
 #=================================================================
 
 def dd_shellvoidshell(*args):    
@@ -1280,6 +1355,35 @@ def dd_shellvoidshell(*args):
     http://doi.org/10.1016/j.jmr.2013.01.007
 
     """  
+    def model(r,p):        
+        # Compute the model distance distribution
+        R1 = float(p[0])
+        w1 = float(p[1])
+        w2 = float(p[2])
+        d  = float(p[3])
+
+        R2 = R1 + w1
+        R3 = R1 + w1 + w2
+        R4 = R1 + w1 + w2 + d
+
+        delta21 = R2**3 - R1**3
+        delta31 = R3**3 - R1**3
+        q31 = delta31*_pbs(r,R1,R3)
+        delta32 = R3**3 - R2**3
+        q32 = delta32*_pbs(r,R2,R3)
+        delta41 = R4**3 - R1**3
+        q41 = delta41*_pbs(r,R1,R4)
+        delta42 = R4**3 - R2**3
+        q42 = delta42*_pbs(r,R2,R4)
+        delta43 = R4**3 - R3**3
+
+        P = (R1**3*(q31 - q41) + R2**3*(q42 - q32))/(delta43*delta21)
+        P = np.round(P,15)
+
+        P = _normalize(r,P)
+
+        return P
+        
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
@@ -1287,37 +1391,13 @@ def dd_shellvoidshell(*args):
             Lower = np.asarray([0.1, 0.1, 0.1, 0.1]),
             Upper = np.asarray([20,  20, 20, 2]),
             Start = np.asarray([0.75, 1, 1, 0.5]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=4)
-        
-    # Compute the model distance distribution
-    R1 = float(p[0])
-    w1 = float(p[1])
-    w2 = float(p[2])
-    d  = float(p[3])
-
-    R2 = R1 + w1
-    R3 = R1 + w1 + w2
-    R4 = R1 + w1 + w2 + d
-
-    delta21 = R2**3 - R1**3
-    delta31 = R3**3 - R1**3
-    q31 = delta31*_pbs(r,R1,R3)
-    delta32 = R3**3 - R2**3
-    q32 = delta32*_pbs(r,R2,R3)
-    delta41 = R4**3 - R1**3
-    q41 = delta41*_pbs(r,R1,R4)
-    delta42 = R4**3 - R2**3
-    q42 = delta42*_pbs(r,R2,R4)
-    delta43 = R4**3 - R3**3
-
-    P = (R1**3*(q31 - q41) + R2**3*(q42 - q32))/(delta43*delta21)
-    P = np.round(P,15)
-
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=4)
+        P = model(r,p)
+        return P
 #=================================================================
 
 
@@ -1371,6 +1451,26 @@ def dd_shellvoidsphere(*args):
     http://doi.org/10.1016/j.jmr.2013.01.007
 
     """  
+    def model(r,p):    
+        # Compute the model distance distribution
+        R1 = float(p[0])
+        w  = float(p[1])
+        d  = float(p[2])
+
+        R2 = R1 + w
+        R3 = R1 + w + d
+
+        delta21 = R2**3 - R1**3
+        q21 = delta21*_pbs(r,R1,R2)
+        delta31 = R3**3 - R1**3
+        q31 = delta31*_pbs(r,R1,R3)
+        delta32 = R3**3 - R2**3
+        
+        P = (q31 - q21)/delta32
+        P = np.round(P,15)
+        P = _normalize(r,P)
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
@@ -1378,30 +1478,13 @@ def dd_shellvoidsphere(*args):
             Lower = np.asarray([0.1, 0.1, 0.1]),
             Upper = np.asarray([20, 20, 20]),
             Start = np.asarray([1.5, 1, 0.5]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=3)
-        
-    # Compute the model distance distribution
-    R1 = float(p[0])
-    w  = float(p[1])
-    d  = float(p[2])
-
-    R2 = R1 + w
-    R3 = R1 + w + d
-
-    delta21 = R2**3 - R1**3
-    q21 = delta21*_pbs(r,R1,R2)
-    delta31 = R3**3 - R1**3
-    q31 = delta31*_pbs(r,R1,R3)
-    delta32 = R3**3 - R2**3
-
-    P = (q31 - q21)/delta32
-    P = np.round(P,15)
-
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=3)
+        P = model(r,p)
+        return P
 #=================================================================
 
 
@@ -1455,6 +1538,13 @@ def dd_sphere(*args):
     http://doi.org/10.1016/j.jmr.2013.01.007
 
     """  
+    def model(r,p):    
+        # Compute the model distance distribution
+        R = float(p[0])
+        P = _pb(r,R)
+        P = _normalize(r,P)
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
@@ -1462,17 +1552,13 @@ def dd_sphere(*args):
             Lower = np.asarray([0.1, 0.1, 0.1]),
             Upper = np.asarray([20,  20, 20]),
             Start = np.asarray([1.5, 1, 0.5]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=3)
-        
-    # Compute the model distance distribution
-    R = float(p[0])
-    P = _pb(r,R)
-
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=3)
+        P = model(r,p)
+        return P
 #=================================================================
 
 
@@ -1523,6 +1609,24 @@ def dd_triangle(*args):
      ---------------------------------------------
 
     """  
+    def model(r,p):    
+        # Compute the model distance distribution
+        r0 = p[0]
+        wL = abs(p[1])
+        wR = abs(p[2])
+        rL = r0 - wL
+        rR = r0 + wR
+        idxL = (r >= r0-wL) & (r <= r0)
+        idxR = (r <= r0+wR) & (r >= r0)
+        P = np.zeros(len(r))
+        if wL>0:
+            P[idxL] = (r[idxL]-rL)/wL/(wL+wR)
+        if wR>0:
+            P[idxR] = -(r[idxR]-rR)/wR/(wL+wR)
+        P = _normalize(r,P)
+        return P
+
+
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
@@ -1530,27 +1634,13 @@ def dd_triangle(*args):
             Lower = np.asarray([1, 0.1, 0.1]),
             Upper = np.asarray([20,  20, 20]),
             Start = np.asarray([3.5, 1, 0.5]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=3)
-        
-    # Compute the model distance distribution
-    r0 = p[0]
-    wL = abs(p[1])
-    wR = abs(p[2])
-    rL = r0 - wL
-    rR = r0 + wR
-    idxL = (r >= r0-wL) & (r <= r0)
-    idxR = (r <= r0+wR) & (r >= r0)
-    P = np.zeros(len(r))
-    if wL>0:
-        P[idxL] = (r[idxL]-rL)/wL/(wL+wR)
-    if wR>0:
-        P[idxR] = -(r[idxR]-rR)/wR/(wL+wR)
-
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=3)
+        P = model(r,p)
+        return P
 #=================================================================
 
 
@@ -1600,6 +1690,15 @@ def dd_uniform(*args):
      --------------------------------------------
 
     """  
+    def model(r,p):    
+        # Compute the model distance distribution
+        rL = min(abs(p))
+        rR = max(abs(p))
+        P = np.zeros(len(r))
+        P[(r>=rL) & (r<=rR)] = 1
+        P = _normalize(r,P)
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
@@ -1607,19 +1706,13 @@ def dd_uniform(*args):
             Lower = np.asarray([0.1, 0.2]),
             Upper = np.asarray([6, 20]),
             Start = np.asarray([2.5, 3]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=2)
-        
-    # Compute the model distance distribution
-    rL = min(abs(p))
-    rR = max(abs(p))
-    P = np.zeros(len(r))
-    P[(r>=rL) & (r<=rR)] = 1
-
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=2)
+        P = model(r,p)
+        return P
 #=================================================================
 
 
@@ -1690,6 +1783,14 @@ def dd_wormchain(*args):
     https://doi.org/10.1103/PhysRevLett.77.2581
 
     """  
+    def model(r,p):    
+        # Compute the model distance distribution
+        L = p[0]
+        Lp = p[1]
+        P = wlc(r,L,Lp)
+        P = _normalize(r,P)
+        return P
+
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
@@ -1697,18 +1798,13 @@ def dd_wormchain(*args):
             Lower = np.asarray([1.5, 2]),
             Upper = np.asarray([20, 100]),
             Start = np.asarray([3.7, 10]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=2)
-    
-    # Compute the model distance distribution
-    L = p[0]
-    Lp = p[1]
-    P = wlc(r,L,Lp)
-
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=2)
+        P = model(r,p)
+        return P
 #=================================================================
 
 
@@ -1763,6 +1859,32 @@ def dd_wormgauss(*args):
     https://doi.org/10.1103/PhysRevLett.77.2581
 
     """  
+    def model(r,p):        
+        # Compute the model distance distribution
+        L = p[0]
+        Lp = p[1]
+        sigma = p[2]
+        P = wlc(r,L,Lp)
+
+        # Compute Gaussian convolution window
+        idx = np.argmax(P)
+        gauss = np.exp(-((r - r[idx])/sigma)**2)
+        
+        # Convolution with size retention
+        P = np.convolve(gauss,P,mode='full')
+
+        # Adjust new convoluted axis
+        idxconv = np.argmax(P)
+        rconv = np.linspace(min(r),max(r)*2,len(P))
+        rconv = rconv - abs(r[idx] - rconv[idxconv])
+
+        #Interpolate down to original axis
+        P = np.interp(r,rconv,P)
+        print(P.shape)
+        P = _normalize(r,P)
+
+        return P
+        
     if not args:
         info = dict(
             Parameters = ('Number of residues','Segment length','Scaling exponent'),
@@ -1770,32 +1892,11 @@ def dd_wormgauss(*args):
             Lower = np.asarray([1.5, 2, 0.001]),
             Upper = np.asarray([20, 100, 2]),
             Start = np.asarray([3.7, 10, 0.2]),
+            ModelFcn = model
         )
         return info
-    r,p = _parsargs(args,npar=3)
-    
-    # Compute the model distance distribution
-    L = p[0]
-    Lp = p[1]
-    sigma = p[2]
-    P = wlc(r,L,Lp)
-
-    # Compute Gaussian convolution window
-    idx = np.argmax(P)
-    gauss = np.exp(-((r - r[idx])/sigma)**2)
-    
-    # Convolution with size retention
-    P = np.convolve(gauss,P,mode='full')
-
-    # Adjust new convoluted axis
-    idxconv = np.argmax(P)
-    rconv = np.linspace(min(r),max(r)*2,len(P))
-    rconv = rconv - abs(r[idx] - rconv[idxconv])
-
-    #Interpolate down to original axis
-    P = np.interp(r,rconv,P)
-    print(P.shape)
-    P = _normalize(r,P)
-
-    return P
+    else: 
+        r,p = _parsargs(args,npar=3)
+        P = model(r,p)
+        return P
 #=================================================================

--- a/deerlab/ex_models.py
+++ b/deerlab/ex_models.py
@@ -44,7 +44,9 @@ def ex_4pdeer(param=None):
         * ``info['Units']`` - string list of metric units of parameters
         * ``info['Start']`` - list of values used as start values during optimization 
         * ``info['Lower']`` - list of values used as lower bounds during optimization 
-        * ``info['Upper']`` - list of values used as upper bounds during optimization 
+        * ``info['Upper']`` - list of values used as upper bounds during optimization  
+        * ``info['ModelFcn']`` - function used to calculate the model output
+        
     pathways : ndarray
         Dipolar pathways of the experiment
 
@@ -58,22 +60,28 @@ def ex_4pdeer(param=None):
      Modulation depth               0        1       0.3 
      -------------------------------------------------------
     """  
+    def model(param):     
+        # Dipolar pathways
+        lam = param[0]
+        pathways = [
+            [1-lam],
+            [lam, 0]
+        ]
+        return pathways
+        
     if param is None:
         info = dict(
             Parameters = ['Modulation depth'],
             Units = [''],
             Start = np.asarray([0.3]),
             Lower = np.asarray([0]),
-            Upper = np.asarray([1])
+            Upper = np.asarray([1]),
+            ModelFcn = model
         )
         return info
-    param = _parsargs(param,npar=1)
-
-    # Dipolar pathways
-    lam = param[0]
-    pathways = [[1-lam], [lam, 0]]
-    
-    return pathways
+    else:
+        param = _parsargs(param, npar=1) 
+        return model(param) 
 # ===================================================================
 
 
@@ -106,7 +114,9 @@ def ex_ovl4pdeer(param=None):
         * ``info['Units']`` - string list of metric units of parameters
         * ``info['Start']`` - list of values used as start values during optimization 
         * ``info['Lower']`` - list of values used as lower bounds during optimization 
-        * ``info['Upper']`` - list of values used as upper bounds during optimization 
+        * ``info['Upper']`` - list of values used as upper bounds during optimization  
+        * ``info['ModelFcn']`` - function used to calculate the model output
+        
     pathways : ndarray
         Dipolar pathways of the experiment
 
@@ -122,6 +132,16 @@ def ex_ovl4pdeer(param=None):
       Refocusing time of 2nd modulated pathway   μs      0       20        5        
      ---------------------------------------------------------------------------
     """  
+    def model(param):   
+        # Dipolar pathways
+        lam = param[[0,1,2]]
+        T0 = param[3]
+        pathways = [[] for _ in lam]
+        pathways[0] = [lam[0]]
+        pathways[1] = [lam[1], 0]
+        pathways[2] = [lam[2], T0]  
+        return pathways  
+
     if param is None:
         info = dict(
             Parameters = ['Amplitude of unmodulated components','Amplitude of 1st modulated pathway',
@@ -129,17 +149,13 @@ def ex_ovl4pdeer(param=None):
             Units = ['','','','μs'],
             Start = np.asarray([0.7, 0.3, 0.1, 5]),
             Lower = np.asarray([0, 0, 0, 0]),
-            Upper = np.asarray([1, 1, 1, 20])
+            Upper = np.asarray([1, 1, 1, 20]),
+            ModelFcn = model
         )
         return info
-    param = _parsargs(param,npar=4)
-
-    # Dipolar pathways
-    lam = param[[0,1,2]]
-    T02 = param[3]
-    pathways = [[lam[0]], [lam[1], 0], [lam[2], T02]]
-    
-    return pathways
+    else:
+        param = _parsargs(param, npar=4) 
+        return model(param) 
 # ===================================================================
 
 
@@ -173,7 +189,9 @@ def ex_5pdeer(param=None):
         * ``info['Units']`` - string list of metric units of parameters
         * ``info['Start']`` - list of values used as start values during optimization 
         * ``info['Lower']`` - list of values used as lower bounds during optimization 
-        * ``info['Upper']`` - list of values used as upper bounds during optimization 
+        * ``info['Upper']`` - list of values used as upper bounds during optimization  
+        * ``info['ModelFcn']`` - function used to calculate the model output
+        
     pathways : ndarray
         Dipolar pathways of the experiment
  
@@ -189,23 +207,29 @@ def ex_5pdeer(param=None):
       Refocusing time of 2nd modulated pathway   μs      0       20        5        
      ---------------------------------------------------------------------------
     """  
+    def model(param):   
+                  # Dipolar pathways
+        lam = param[[0,1,2]]
+        T0 = param[3]
+        pathways = [[] for _ in lam]
+        pathways[0] = [lam[0]]
+        pathways[1] = [lam[1], 0]
+        pathways[2] = [lam[2], T0]
+        return pathways  
+
     if param is None:
         info = dict(
             Parameters = ['Amplitude of unmodulated components','Amplitude of 1st modulated pathway','Amplitude of 2nd modulated pathway','Refocusing time of 2nd modulated pathway'],
             Units = ['','','','μs'],
             Start = np.asarray([0.4, 0.4, 0.2,5]),
             Lower = np.asarray([0, 0, 0, 0]),
-            Upper = np.asarray([1, 1, 1, 20])
+            Upper = np.asarray([1, 1, 1, 20]),
+            ModelFcn = model
         )
         return info
-    param = _parsargs(param,npar=4)
-
-    # Dipolar pathways
-    lam = param[[0,1,2]]
-    T02 = param[3]
-    pathways = [[lam[0]], [lam[1], 0], [lam[2], T02]]
-    
-    return pathways
+    else:
+        param = _parsargs(param, npar=4) 
+        return model(param) 
 # ===================================================================
 
 
@@ -240,7 +264,9 @@ def ex_7pdeer(param=None):
         * ``info['Units']`` - string list of metric units of parameters
         * ``info['Start']`` - list of values used as start values during optimization 
         * ``info['Lower']`` - list of values used as lower bounds during optimization 
-        * ``info['Upper']`` - list of values used as upper bounds during optimization 
+        * ``info['Upper']`` - list of values used as upper bounds during optimization  
+        * ``info['ModelFcn']`` - function used to calculate the model output
+        
     pathways : ndarray
         Dipolar pathways of the experiment
  
@@ -258,6 +284,17 @@ def ex_7pdeer(param=None):
       Refocusing time of 3rd modulated pathway   μs      0       20       3.5 
      ---------------------------------------------------------------------------
     """  
+    def model(param):   
+        # Dipolar pathways
+        lam = param[[0,1,2,3]]
+        T0 = param[[4,5]]
+        pathways = [[] for _ in lam]
+        pathways[0] = [lam[0]]
+        pathways[1] = [lam[1], 0]
+        pathways[2] = [lam[2], T0[0]]
+        pathways[3] = [lam[3], T0[1]]    
+        return pathways  
+
     if param is None:
         info = dict(
             Parameters = ['Amplitude of unmodulated components','Amplitude of 1st modulated pathway',
@@ -266,19 +303,14 @@ def ex_7pdeer(param=None):
             Units = ['','','','','μs','μs'],
             Start = np.asarray([0.3, 0.5, 0.3, 0.2, 1.5, 3.5]),
             Lower = np.asarray([0, 0, 0, 0, 0, 0]),
-            Upper = np.asarray([1, 1, 1, 1, 20, 20])
+            Upper = np.asarray([1, 1, 1, 1, 20, 20]),
+            ModelFcn = model
         )
         return info
-    param = _parsargs(param,npar=6)
+    else:
+        param = _parsargs(param, npar=6) 
+        return model(param) 
 
-    # Dipolar pathways
-    lam = param[[0,1,2,3]]
-    T02 = param[4]
-    T03 = param[5]
-
-    pathways = [[lam[0]], [lam[1], 0], [lam[2], T02], [lam[3], T03]]
-    
-    return pathways
 # ===================================================================
 
 
@@ -312,7 +344,9 @@ def ex_ridme1(param=None):
         * ``info['Units']`` - string list of metric units of parameters
         * ``info['Start']`` - list of values used as start values during optimization 
         * ``info['Lower']`` - list of values used as lower bounds during optimization 
-        * ``info['Upper']`` - list of values used as upper bounds during optimization 
+        * ``info['Upper']`` - list of values used as upper bounds during optimization  
+        * ``info['ModelFcn']`` - function used to calculate the model output
+        
     pathways : ndarray
         Dipolar pathways of the experiment
  
@@ -326,24 +360,28 @@ def ex_ridme1(param=None):
       Amplitude of 1st harmonic pathway                  0       1        0.5
      ---------------------------------------------------------------------------
     """  
+    def model(param):   
+        # Dipolar pathways
+        lam = param.copy()
+        pathways = [[] for _ in lam]
+        pathways[0] = [lam[0]]
+        pathways[1] = [lam[1], 0, 1]
+        return pathways      
+
     if param is None:
         info = dict(
             Parameters = ['Amplitude of unmodulated contribution','Amplitude of 1st modulated pathway'],
             Units = ['',''],
             Start = np.asarray([0.3, 0.5]),
             Lower = np.asarray([0, 0]),
-            Upper = np.asarray([1, 1])
+            Upper = np.asarray([1, 1]),
+            ModelFcn = model
         )
         return info
-    param = _parsargs(param,npar=2)
+    else:
+        param = _parsargs(param, npar=2) 
+        return model(param) 
 
-    # Dipolar pathways
-    lam = param.copy()
-    pathways = [[] for _ in lam]
-    pathways[0] = [lam[0]]
-    pathways[1] = [lam[1], 0, 1]
-    
-    return pathways
 # ===================================================================
 
 
@@ -378,6 +416,8 @@ def ex_ridme3(param=None):
         * ``info['Start']`` - list of values used as start values during optimization 
         * ``info['Lower']`` - list of values used as lower bounds during optimization 
         * ``info['Upper']`` - list of values used as upper bounds during optimization 
+        * ``info['ModelFcn']`` - function used to calculate the model output
+
     pathways : ndarray
         Dipolar pathways of the experiment
  
@@ -393,6 +433,16 @@ def ex_ridme3(param=None):
       Amplitude of 3rd harmonic pathway                  0       1        0.2
      ---------------------------------------------------------------------------
     """  
+    def model(param):   
+        # Dipolar pathways
+        lam = param.copy()
+        pathways = [[] for _ in lam]
+        pathways[0] = [lam[0]]
+        pathways[1] = [lam[1], 0, 1]
+        pathways[2] = [lam[2], 0, 2]
+        pathways[3] = [lam[3], 0, 3]
+        return pathways
+
     if param is None:
         info = dict(
             Parameters = ['Amplitude of unmodulated contribution','Amplitude of 1st harmonic pathway',
@@ -400,20 +450,14 @@ def ex_ridme3(param=None):
             Units = ['','','',''],
             Start = np.asarray([0.3, 0.5, 0.3, 0.2]),
             Lower = np.asarray([0, 0, 0, 0]),
-            Upper = np.asarray([1, 1, 1, 1])
+            Upper = np.asarray([1, 1, 1, 1]),
+            ModelFcn = model
         )
         return info
-    param = _parsargs(param,npar=4)
+    else:
+        param = _parsargs(param, npar=4) 
+        return model(param) 
 
-    # Dipolar pathways
-    lam = param.copy()
-    pathways = [[] for _ in lam]
-    pathways[0] = [lam[0]]
-    pathways[1] = [lam[1], 0, 1]
-    pathways[2] = [lam[2], 0, 2]
-    pathways[3] = [lam[3], 0, 3]
-    
-    return pathways
 # ===================================================================
 
 
@@ -448,6 +492,8 @@ def ex_ridme5(param=None):
         * ``info['Start']`` - list of values used as start values during optimization 
         * ``info['Lower']`` - list of values used as lower bounds during optimization 
         * ``info['Upper']`` - list of values used as upper bounds during optimization 
+        * ``info['ModelFcn']`` - function used to calculate the model output
+
     pathways : ndarray
         Dipolar pathways of the experiment
  
@@ -465,6 +511,18 @@ def ex_ridme5(param=None):
       Amplitude of 5th harmonic pathway                  0       1        0.05 
      ---------------------------------------------------------------------------
     """  
+    def model(param):     
+        # Dipolar pathways
+        lam = param.copy()
+        pathways = [[] for _ in lam]
+        pathways[0] = [lam[0]]
+        pathways[1] = [lam[1], 0, 1]
+        pathways[2] = [lam[2], 0, 2]
+        pathways[3] = [lam[3], 0, 3]
+        pathways[4] = [lam[4], 0, 4]
+        pathways[5] = [lam[5], 0, 5]
+        return pathways
+
     if param is None:
         info = dict(
             Parameters = ['Amplitude of unmodulated contribution','Amplitude of 1st harmonic pathway',
@@ -473,22 +531,14 @@ def ex_ridme5(param=None):
             Units = ['','','','','',''],
             Start = np.asarray([0.3, 0.5, 0.3, 0.2,0.1,0.05]),
             Lower = np.asarray([0, 0, 0, 0, 0, 0]),
-            Upper = np.asarray([1, 1, 1, 1, 1, 1])
+            Upper = np.asarray([1, 1, 1, 1, 1, 1]),
+            ModelFcn = model
         )
         return info
-    param = _parsargs(param,npar=6)
+    else:
+        param = _parsargs(param, npar=6) 
+        return model(param) 
 
-    # Dipolar pathways
-    lam = param.copy()
-    pathways = [[] for _ in lam]
-    pathways[0] = [lam[0]]
-    pathways[1] = [lam[1], 0, 1]
-    pathways[2] = [lam[2], 0, 2]
-    pathways[3] = [lam[3], 0, 3]
-    pathways[4] = [lam[4], 0, 4]
-    pathways[5] = [lam[5], 0, 5]
-
-    return pathways
 # ===================================================================
 
 
@@ -522,7 +572,8 @@ def ex_ridme7(param=None):
         * ``info['Units']`` - string list of metric units of parameters
         * ``info['Start']`` - list of values used as start values during optimization 
         * ``info['Lower']`` - list of values used as lower bounds during optimization 
-        * ``info['Upper']`` - list of values used as upper bounds during optimization 
+        * ``info['Upper']`` - list of values used as upper bounds during optimization
+        * ``info['ModelFcn']`` - function used to calculate the model output 
     pathways : ndarray
         Dipolar pathways of the experiment
  
@@ -542,6 +593,20 @@ def ex_ridme7(param=None):
       Amplitude of 7th harmonic pathway                  0       1        0.01 
      ---------------------------------------------------------------------------
     """  
+    def model(param):        
+        # Dipolar pathways
+        lam = param.copy()
+        pathways = [[] for _ in lam]
+        pathways[0] = [lam[0]]
+        pathways[1] = [lam[1], 0, 1]
+        pathways[2] = [lam[2], 0, 2]
+        pathways[3] = [lam[3], 0, 3]
+        pathways[4] = [lam[4], 0, 4]
+        pathways[5] = [lam[5], 0, 5]
+        pathways[6] = [lam[6], 0, 6]
+        pathways[7] = [lam[7], 0, 7]
+        return pathways
+
     if param is None:
         info = dict(
             Parameters = ['Amplitude of unmodulated contribution','Amplitude of 1st harmonic pathway',
@@ -551,22 +616,12 @@ def ex_ridme7(param=None):
             Units = ['','','','','','','',''],
             Start = np.asarray([0.3, 0.5, 0.3, 0.2,0.1,0.05,0.02,0.01]),
             Lower = np.asarray([0, 0, 0, 0, 0, 0, 0, 0]),
-            Upper = np.asarray([1, 1, 1, 1, 1, 1, 1, 1])
+            Upper = np.asarray([1, 1, 1, 1, 1, 1, 1, 1]),
+            ModelFcn = model
         )
         return info
-    param = _parsargs(param,npar=8)
+    else:
+        param = _parsargs(param, npar=8) 
+        return model(param) 
 
-    # Dipolar pathways
-    lam = param.copy()
-    pathways = [[] for _ in lam]
-    pathways[0] = [lam[0]]
-    pathways[1] = [lam[1], 0, 1]
-    pathways[2] = [lam[2], 0, 2]
-    pathways[3] = [lam[3], 0, 3]
-    pathways[4] = [lam[4], 0, 4]
-    pathways[5] = [lam[5], 0, 5]
-    pathways[6] = [lam[6], 0, 6]
-    pathways[7] = [lam[7], 0, 7]
-
-    return pathways
 # ===================================================================

--- a/deerlab/fitmultimodel.py
+++ b/deerlab/fitmultimodel.py
@@ -209,6 +209,7 @@ def fitmultimodel(V, Kmodel, r, model, maxModels, method='aic', lb=None, ub=None
     if ub is None:
         ub = info['Upper']
     paramnames = info['Parameters']
+    modelfcn = info['ModelFcn']
 
     if lbK is None:
         lbK = []
@@ -248,7 +249,7 @@ def fitmultimodel(V, Kmodel, r, model, maxModels, method='aic', lb=None, ub=None
             subset = np.arange(paramsused, paramsused+nparam)
             paramsused = paramsused + nparam
             # Get basis functions
-            Pbasis = model(r,par[subset])
+            Pbasis = modelfcn(r,par[subset])
             # Combine all non-linear functions into one
             Knonlin[:,iModel] = K@Pbasis
         return Knonlin
@@ -269,7 +270,7 @@ def fitmultimodel(V, Kmodel, r, model, maxModels, method='aic', lb=None, ub=None
             subset = np.arange(paramsused, paramsused+nparam)
             paramsused = paramsused + nparam
             # Add basis functions
-            Pfit = Pfit + amp*model(r,nlinpar[subset])
+            Pfit = Pfit + amp*modelfcn(r,nlinpar[subset])
         return Pfit
     #===============================================================================
 

--- a/deerlab/fitsignal.py
+++ b/deerlab/fitsignal.py
@@ -270,7 +270,7 @@ def fitsignal(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
     parfreeDistribution = dd_model == 'P' # Check if P(r) is non-parametric model
     includeForeground = np.array(dd_model is not None) # Check if there is a foreground or just background in the model
 
-    par0_dd, lower_dd, upper_dd, N_dd = _getmodelparams(dd_model) # Get model built-in info
+    par0_dd, lower_dd, upper_dd, N_dd, dd_fcn = _getmodelparams(dd_model) # Get model built-in info
 
     # Catch nonsensical case
     if includeForeground and not parametricDistribution and not parfreeDistribution:
@@ -281,7 +281,7 @@ def fitsignal(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
     isparamodel = np.array([type(model) is types.FunctionType for model in bg_model]) # Check if B(t) is a parametric model
     includeBackground = np.array([model is not None for model in bg_model]) # Check if model includes B(t) or not
 
-    par0_bg, lower_bg, upper_bg, N_bg = _getmodelparams(bg_model) # Get model built-in info
+    par0_bg, lower_bg, upper_bg, N_bg, bg_fcn = _getmodelparams(bg_model) # Get model built-in info
 
     # Check whether the background model is a physical or phenomenological model
     isphenomenological = [_iserror(model,t,par0,1) for model,par0 in zip(bg_model,par0_bg)]
@@ -295,7 +295,7 @@ def fitsignal(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
     isparamodel = np.array([type(model) is types.FunctionType for model in ex_model]) # Check if experiment is a parametric model
     includeExperiment = np.array([model is not None for model in ex_model]) # Check whether to include experiment in the model
 
-    par0_ex, lower_ex, upper_ex, N_ex = _getmodelparams(ex_model) # Get model built-in info
+    par0_ex, lower_ex, upper_ex, N_ex, ex_fcn = _getmodelparams(ex_model) # Get model built-in info
 
     # Catch nonsensical situations
     if np.any(~isparamodel & includeExperiment):
@@ -336,15 +336,15 @@ def fitsignal(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
             # Prepare background basis function
             if includeBackground[iSignal]:
                 if isphenomenological[iSignal]:
-                    Bfcn = lambda t: bg_model[iSignal](t,bg_par)
+                    Bfcn = lambda t: bg_fcn[iSignal](t,bg_par)
                 else:
-                    Bfcn = lambda t,lam: bg_model[iSignal](t,bg_par,lam)
+                    Bfcn = lambda t,lam: bg_fcn[iSignal](t,bg_par,lam)
             else:
                 Bfcn = lambda _,__: np.ones_like(Vexp[iSignal])
             
             # Get pathway information
             if includeExperiment[iSignal]:
-                pathways = ex_model[iSignal](ex_par)
+                pathways = ex_fcn[iSignal](ex_par)
             else:
                 pathways = 1
             
@@ -841,24 +841,26 @@ def _getmodelparams(models):
     if type(models) is not list:
         models = [models]
 
-    par0,lo,up,N = ([],[],[],[])
+    par0,lo,up,N,modelfcn = ([],[],[],[],[])
     for model in models:
         if type(model) is types.FunctionType:
             info = model()
             par0.append(info['Start'])
             lo.append(info['Lower'])
             up.append(info['Upper'])
+            modelfcn.append(info['ModelFcn'])
         else:
             par0.append([])
             lo.append([])
             up.append([])
+            modelfcn.append([])
         N.append(len(par0[-1]))
 
     par0 = np.concatenate(par0)
     lo = np.concatenate(lo)
     up = np.concatenate(up)
     N = np.atleast_1d(N)
-    return par0,lo,up,N
+    return par0,lo,up,N,modelfcn
 # ==============================================================================
 
 def _parcombine(p,d):


### PR DESCRIPTION
As described in #100, the functions that often call DeerLab's built-in models suffer from some heavy overhead leading to a serious slow-down of the runtime.  

By implementing the way of avoiding call overhead described in #100 we can speed up the execution of the fit functions. Mostly affected are: 
- **fitsignal**: about a factor x2 acceleration
- **fitmultimodel**: about a factor x7-14 acceleration

Here are some benchmark results showing the acceleration in more detail: 

#### ``fitsignal`` (before)
```
=================================================== test session starts 
platform win32 -- Python 3.8.0, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: D:\lufa\projects\DeerLab\DeerLab
collected 44 items                                                                                                                                                                                                                                                                                                  

test\test_fitsignal.py ............................................                                                                                                                                                                                                                                          [100%] 

================================================== slowest 10 durations 
24.30s call     test/test_fitsignal.py::test_ridme5
11.39s call     test/test_fitsignal.py::test_cost_value
10.31s call     test/test_fitsignal.py::test_ovl4pdeer
9.51s call     test/test_fitsignal.py::test_ridme3
9.00s call     test/test_fitsignal.py::test_5pdeer
6.87s call     test/test_fitsignal.py::test_7pdeer
6.12s call     test/test_fitsignal.py::test_global_4pdeer
4.63s call     test/test_fitsignal.py::test_global_full_parametric
4.31s call     test/test_fitsignal.py::test_global_scale_4pdeer
3.83s call     test/test_fitsignal.py::test_boundaries_adjust_ex
================================================== 44 passed in 133.21s
```
#### ``fitsignal`` (now)
```
================================================== test session starts 
rootdir: D:\lufa\projects\DeerLab\DeerLab
collected 44 items                                                                                                                                                                                                                                                                                                  

test\test_fitsignal.py ............................................                                                                                                                                                                                                                                          [100%] 

================================================== slowest 10 durations 
6.15s call     test/test_fitsignal.py::test_ovl4pdeer
5.43s call     test/test_fitsignal.py::test_7pdeer
3.95s call     test/test_fitsignal.py::test_cost_value
3.78s call     test/test_fitsignal.py::test_ridme5
3.35s call     test/test_fitsignal.py::test_5pdeer
2.89s call     test/test_fitsignal.py::test_boundaries_adjust_ex
2.31s call     test/test_fitsignal.py::test_ridme1
2.07s call     test/test_fitsignal.py::test_ridme3
1.92s call     test/test_fitsignal.py::test_global_4pdeer
1.90s call     test/test_fitsignal.py::test_plot
================================================== 44 passed in 54.60s
```
#### ``fitmultimodel`` (before)
```
====================================================================================== test session starts 
platform win32 -- Python 3.8.0, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: D:\lufa\projects\DeerLab\DeerLab
collected 20 items                                                                                                                                                                                                                                                                                                  

test\test_fitmultimodel.py ....................                                                                                                                                                                                                                                                              [100%] 

====================================================================================== slowest 10 durations  
15.87s call     test/test_fitmultimodel.py::test_rescaling
14.08s call     test/test_fitmultimodel.py::test_multirice_split
13.98s call     test/test_fitmultimodel.py::test_multirice
9.75s call     test/test_fitmultimodel.py::test_global_multirice
8.60s call     test/test_fitmultimodel.py::test_multigauss_spread
7.23s call     test/test_fitmultimodel.py::test_multirice_spread
6.59s call     test/test_fitmultimodel.py::test_multigauss_merge
6.54s call     test/test_fitmultimodel.py::test_multirice_merge
5.23s call     test/test_fitmultimodel.py::test_multigauss
5.08s call     test/test_fitmultimodel.py::test_plot
======================================================================================20 passed in 128.47s (0:02:08)
```
#### ``fitmultimodel`` (now)
```
====================================================================================== test session starts 
platform win32 -- Python 3.8.0, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: D:\lufa\projects\DeerLab\DeerLab
collected 20 items                                                                                                                                                                                                                                                                                                  

test\test_fitmultimodel.py ....................                                                                                                                                                                                                                                                              [100%] 

====================================================================================== slowest 10 durations  
2.05s call     test/test_fitmultimodel.py::test_background_fit
0.75s call     test/test_fitmultimodel.py::test_plot
0.69s call     test/test_fitmultimodel.py::test_multirice
0.69s call     test/test_fitmultimodel.py::test_multirice_split
0.45s call     test/test_fitmultimodel.py::test_rescaling
0.44s call     test/test_fitmultimodel.py::test_multirice_spread
0.42s call     test/test_fitmultimodel.py::test_multigauss
0.38s call     test/test_fitmultimodel.py::test_multirice_merge
0.33s call     test/test_fitmultimodel.py::test_global_multirice
0.31s call     test/test_fitmultimodel.py::test_multigauss_spread
====================================================================================== 20 passed in 8.90s
```

Closes #100 