### PR TITLE
Expose convergence criteria keyword arguments to all fit functions

### DIFF
--- a/deerlab/fitmultimodel.py
+++ b/deerlab/fitmultimodel.py
@@ -12,7 +12,7 @@ from deerlab.utils import hccm, goodness_of_fit, Jacobian
 from deerlab.classes import FitResult
 
 def fitmultimodel(V, Kmodel, r, model, maxModels, method='aic', lb=None, ub=None, lbK=None, ubK=None,
-                 strategy='split', weights=1, renormalize = True, uqanalysis=True, **kwargs):
+                 strategy='split', weights=1, renormalize = True, uqanalysis=True, tol=1e-9, maxiter=1e8):
     r""" 
     Fits a multi-model parametric distance distribution model to a dipolar signal using separable 
     non-linear least-squares (SNLLS).
@@ -78,6 +78,12 @@ def fitmultimodel(V, Kmodel, r, model, maxModels, method='aic', lb=None, ub=None
     
     uqanalysis : boolean, optional
         Enable/disable the uncertainty quantification analysis, by default it is enabled.  
+
+    tol : scalar, optional 
+        Tolerance value for convergence of the NNLS algorithm. If not specified, the value is set to ``tol = 1e-9``.
+        
+    maxiter: scalar, optional  
+        Maximum number of iterations before termination. If not specified, the value is set to ``maxiter = 1e8``.
 
     Returns
     -------
@@ -413,7 +419,7 @@ def fitmultimodel(V, Kmodel, r, model, maxModels, method='aic', lb=None, ub=None
         # Separable non-linear least-squares (SNLLS) fit
         scale = 1e2
         fit = dl.snlls(V*scale,Knonlin,par0,nlin_lb,nlin_ub,lin_lb,lin_ub, 
-                        weights=weights, reg=False, uqanalysis=False, lin_tol=[], lin_maxiter=[],**kwargs)
+                        weights=weights, reg=False, uqanalysis=False, nonlin_tol=tol, nonlin_maxiter=maxiter)
         pnonlin = fit.nonlin
         plin = fit.lin
         par_prev = pnonlin

--- a/deerlab/fitregmodel.py
+++ b/deerlab/fitregmodel.py
@@ -13,9 +13,10 @@ from deerlab.classes import UncertQuant, FitResult
 
 def fitregmodel(V,K,r, regtype='tikhonov', regparam='aic', regorder=2, solver='cvx', 
                 weights=1, huberparam=1.35, nonnegativity=True, obir = False, 
-                uqanalysis=True, renormalize=True, noiselevelaim = -1):
+                uqanalysis=True, renormalize=True, noiselevelaim = -1,tol=None,maxiter=None):
     r"""
-    Fits a non-parametric distance distribution to one (or several) signals using regularization aproaches.
+    Fits a non-parametric distance distribution to one (or several) signals using regularization aproaches 
+    via non-negative least-squares (NNLS).
 
     Parameters 
     ----------
@@ -88,6 +89,13 @@ def fitregmodel(V,K,r, regtype='tikhonov', regparam='aic', regorder=2, solver='c
     noiselevelaim : scalar, optional
         Noise level at which to stop the OBIR algorithm. If not specified it is automatically estimated from the fit residuals.
 
+    tol : scalar, optional 
+        Tolerance value for convergence of the NNLS algorithm. If not specified (``None``), the value is set automatically to ``tol = max(K.T@K.shape)*norm(K.T@K,1)*eps``.
+        It is only valid for the ``'cvx'`` and ``'fnnls'`` solvers, it has no effect on the ``'nnlsbpp'`` solver.
+        
+    maxiter: scalar, optional  
+        Maximum number of iterations before termination. If not specified (``None``), the value is set automatically to ``maxiter = 5*shape(K.T@K)[1]``.
+        It is only valid for the ``'cvx'`` and ``'fnnls'`` solvers, it has no effect on the ``'nnlsbpp'`` solver.
 
     Returns
     -------
@@ -166,11 +174,11 @@ def fitregmodel(V,K,r, regtype='tikhonov', regparam='aic', regorder=2, solver='c
     elif problem == 'nnls':
 
         if solver == 'fnnls':
-            Pfit = fnnls(KtKreg,KtV)
+            Pfit = fnnls(KtKreg,KtV,tol=tol,maxiter=maxiter)
         elif solver == 'nnlsbpp':
             Pfit = nnlsbpp(KtKreg,KtV,np.linalg.solve(KtKreg,KtV))
         elif solver == 'cvx':
-            Pfit = cvxnnls(KtKreg, KtV)
+            Pfit = cvxnnls(KtKreg, KtV,tol=tol,maxiter=maxiter)
         else:
             raise KeyError(f'{solver} is not a known non-negative least squares solver')
 

--- a/deerlab/nnls.py
+++ b/deerlab/nnls.py
@@ -7,7 +7,7 @@ import numpy as np
 import cvxopt as cvx
 import math as m
 
-def fnnls(AtA,Atb,tol=[],maxiter=[],verbose=False):
+def fnnls(AtA, Atb, tol=None, maxiter=None, verbose=False):
 #=====================================================================================
     r"""
     FNNLS   Fast non-negative least-squares algorithm.
@@ -36,10 +36,10 @@ def fnnls(AtA,Atb,tol=[],maxiter=[],verbose=False):
     x = np.zeros(N)
 
     # Calculate tolerance and maxiter if not given.
-    if np.size(np.atleast_1d(tol))==0:
+    if tol is None:
         eps = np.finfo(float).eps
         tol = 10*eps*np.linalg.norm(AtA,1)*max(np.shape(AtA))
-    if np.size(np.atleast_1d(maxiter))==0:
+    if maxiter is None:
         maxiter = 5*N
 
 
@@ -117,7 +117,7 @@ def fnnls(AtA,Atb,tol=[],maxiter=[],verbose=False):
 
 
 
-def cvxnnls(AtA, Atb, tol=[], maxiter=[]):
+def cvxnnls(AtA, Atb, tol=None, maxiter=None):
 #=====================================================================================
     """
     NNLS problem solved via CVXOPT
@@ -132,10 +132,10 @@ def cvxnnls(AtA, Atb, tol=[], maxiter=[]):
     """
 
     N = np.shape(AtA)[1]
-    if np.size(np.atleast_1d(tol))==0:
+    if tol is None:
         eps = np.finfo(float).eps
         tol = 10*eps*np.linalg.norm(AtA,1)*max(np.shape(AtA))
-    if np.size(np.atleast_1d(maxiter)):
+    if maxiter is None:
         maxiter = 5*N
 
     x0 = np.zeros(N)
@@ -158,7 +158,7 @@ def cvxnnls(AtA, Atb, tol=[], maxiter=[]):
 #=====================================================================================
 
 
-def nnlsbpp(AtA,AtB,x0=None):
+def nnlsbpp(AtA, AtB, x0=None):
 #=====================================================================================
     """
     Non-Negative Least Squares using Block Principal Pivoting

--- a/test/test_fitmodel.py
+++ b/test/test_fitmodel.py
@@ -561,7 +561,7 @@ def test_V_scale_parametric():
 
     fit = fitmodel(V,t,r,dd_gauss,bg_exp,ex_4pdeer,uq=None)
 
-    assert max(abs(1 - V/fit.V)) < 1e-4
+    assert isinstance(fit.scale,float) and  abs(1 - scale/fit.scale) < 1e-2
 # ======================================================================
 
 def test_V_scale():
@@ -577,7 +577,7 @@ def test_V_scale():
 
     fit = fitmodel(V,t,r,'P',bg_exp,ex_4pdeer,uq=None)
 
-    assert max(abs(1 - V/fit.V)) < 1e-4
+    assert isinstance(fit.scale,float) and abs(1 - scale/fit.scale) < 1e-2
 # ======================================================================
 
 def test_V_scale_regularized():
@@ -592,7 +592,7 @@ def test_V_scale_regularized():
 
     fit = fitmodel(V,t,r,'P',None,None,uq=None)
 
-    assert max(abs(1 - V/fit.V)) < 1e-4
+    assert isinstance(fit.scale,float) and  abs(1 - scale/fit.scale) < 1e-2
 # ======================================================================
 
 def test_plot():
@@ -773,4 +773,21 @@ def test_bootci_bparam():
 # ======================================================================
     "Check that the bootstrapped confidence intervals work"
     assert_boot_ci('bgparam')
+# ======================================================================
+
+def test_convergence_criteria():
+# ======================================================================
+    "Check that convergence criteria can be specified without crashing"
+
+    t = np.linspace(0,5,100)
+    r = np.linspace(2,6,150)
+    P = dd_gauss(r,[4.5, 0.25])
+
+    Bmodel = lambda t: bg_exp(t,0.4)
+    K = dipolarkernel(t,r,0.4,Bmodel)
+    V = K@P
+
+    fit = fitmodel(V,t,r,'P',bg_exp,ex_4pdeer,uq=None,tol=1e-3,maxiter=1e2)
+
+    assert ovl(P,fit.P) > 0.90
 # ======================================================================

--- a/test/test_fitmultimodel.py
+++ b/test/test_fitmultimodel.py
@@ -380,3 +380,20 @@ def test_cost_value():
     
     assert isinstance(fit.cost,float) and np.round(fit.cost/np.sum(fit.residuals**2),5)==1
 #=======================================================================
+
+
+def test_convergence_criteria():
+#=======================================================================
+    "Check that convergence criteria can be specified without crashing"
+        
+    r = np.linspace(2,6,300)
+    t = np.linspace(-0.5,6,500)
+    K = dipolarkernel(t,r)
+    parin = [4, 0.05, 0.4, 4, 0.4, 0.4, 3, 0.15, 0.2]
+    P = dd_gauss3(r,parin)
+    V = K@P
+
+    fit = fitmultimodel(V,K,r,dd_gauss,3,'aicc', uqanalysis=False, tol=1e-3, maxiter=200)
+    
+    assert ovl(P,fit.P) > 0.95 # more than 99% overlap
+#=======================================================================

--- a/test/test_fitregmodel.py
+++ b/test/test_fitregmodel.py
@@ -420,3 +420,18 @@ def test_cost_value():
 
     assert isinstance(fit.cost,float) and np.round(fit.cost/np.sum(fit.residuals**2),5)==1
 #============================================================
+
+def test_convergence_criteria():
+#============================================================
+    "Check that convergence criteria can be specified without crashing"
+
+    t = np.linspace(0,3,200)
+    r = np.linspace(1,5,100)
+    P = dd_gauss(r,[3,0.08])
+    K = dipolarkernel(t,r)
+    V = K@P
+
+    fit = fitregmodel(V,K,r,'tikhonov','aic',tol=1e-9,maxiter=2e3)
+  
+    assert ovl(P,fit.P) > 0.90 # more than 80% overlap
+#============================================================


### PR DESCRIPTION
Add the keyword arguments `tol` and `maxiter` to all fit functions missing them.

Closes #112 