### PR TITLE
fitparamodel: rename rescale keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Release v0.13.0 - March 2021
     - Implemented the constraint ``Lam0+sum(lam)<=1`` to ensure the structural-identifiability of ``Lam0`` and ``V0`` during SNLLS optimization of experiment models with more than one modulated dipolar pathway (i.e. does not affect ``ex_4pdeer``) ([#76](https://github.com/JeschkeLab/DeerLab/issues/76),[#108](https://github.com/JeschkeLab/DeerLab/pull/108)).
 - ``fitparamodel``: 
     - Made ``par0`` a positional argument instead of an optional keyword ([#70](https://github.com/JeschkeLab/DeerLab/issues/70)). to avoid errors when not defined ([#69](https://github.com/JeschkeLab/DeerLab/issues/69)).
-    - Keyword argument ``rescale`` has been renamed to ``fitscale`` ([#124])https://github.com/JeschkeLab/DeerLab/issues/128)).
+    - Keyword argument ``rescale`` has been renamed to ``fitscale`` ([#128])https://github.com/JeschkeLab/DeerLab/issues/128)).
 - ``snlls``:
     - Corrected bug that was leading to the smoothness penalty being accounted for twice in the least-squares residual during optimization ([#103](https://github.com/JeschkeLab/DeerLab/issues/103)).
     - Now returns the uncertainty quantification of linear and nonlinear parts as separate objects ``nonlinUncert`` and ``linUncert`` ([#108](https://github.com/JeschkeLab/DeerLab/pull/108)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Release v0.13.0 - March 2021
     - Implemented the constraint ``Lam0+sum(lam)<=1`` to ensure the structural-identifiability of ``Lam0`` and ``V0`` during SNLLS optimization of experiment models with more than one modulated dipolar pathway (i.e. does not affect ``ex_4pdeer``) ([#76](https://github.com/JeschkeLab/DeerLab/issues/76),[#108](https://github.com/JeschkeLab/DeerLab/pull/108)).
 - ``fitparamodel``: 
     - Made ``par0`` a positional argument instead of an optional keyword ([#70](https://github.com/JeschkeLab/DeerLab/issues/70)). to avoid errors when not defined ([#69](https://github.com/JeschkeLab/DeerLab/issues/69)).
+    - Keyword argument ``rescale`` has been renamed to ``fitscale`` ([#124])https://github.com/JeschkeLab/DeerLab/issues/128)).
 - ``snlls``:
     - Corrected bug that was leading to the smoothness penalty being accounted for twice in the least-squares residual during optimization ([#103](https://github.com/JeschkeLab/DeerLab/issues/103)).
     - Now returns the uncertainty quantification of linear and nonlinear parts as separate objects ``nonlinUncert`` and ``linUncert`` ([#108](https://github.com/JeschkeLab/DeerLab/pull/108)).

--- a/deerlab/correctscale.py
+++ b/deerlab/correctscale.py
@@ -77,7 +77,7 @@ Vc : ndarray
         raise KeyError("Unknown model '{}'".format(model))
 
     # Run the parametric model fitting
-    fit = fitparamodel(V_,fitmodel,par0,lb,ub,rescale=False,uq=False)
+    fit = fitparamodel(V_,fitmodel,par0,lb,ub,fitscale=False,uq=False)
 
     # Get the fitted signal amplitude and scale the signal
     V0 = Amp0*fit.param[0]

--- a/examples/plot_emulating_deeranalysis_workflow.py
+++ b/examples/plot_emulating_deeranalysis_workflow.py
@@ -66,7 +66,7 @@ def Bmodel(par):
 par0 = [0.5,   0.5, 3]
 lb   = [0.1,    0,  1]
 ub   = [1,      5,  6]
-fit = dl.fitparamodel(V[mask],Bmodel,par0,lb,ub,rescale=False)
+fit = dl.fitparamodel(V[mask],Bmodel,par0,lb,ub,fitscale=False)
 
 lamfit,kappa,d = fit.param
 Bfit = dl.bg_strexp(t,[kappa,d])

--- a/examples/plot_extracting_gauss_constraints.py
+++ b/examples/plot_extracting_gauss_constraints.py
@@ -71,7 +71,7 @@ lb = info['Lower']
 ub = info['Upper']
 
 # Fit the Gaussians
-fit = dl.fitparamodel(Pfit,Pmodel,par0,lb,ub,covmatrix=Pfit_covmat,rescale=False)
+fit = dl.fitparamodel(Pfit,Pmodel,par0,lb,ub,covmatrix=Pfit_covmat,fitscale=False)
 
 # Extract the fit results
 parfit = fit.param

--- a/test/test_fitparamodel.py
+++ b/test/test_fitparamodel.py
@@ -85,8 +85,8 @@ def test_rescaling():
     ub = [20, 5]
     mymodel = lambda param: dipolarkernel(t,r)@dd_gauss(r,param)
 
-    fit1 = fitparamodel(V*scale,mymodel,par0,lb,ub,rescale=True)
-    fit2 = fitparamodel(V,mymodel,par0,lb,ub,rescale=False)
+    fit1 = fitparamodel(V*scale,mymodel,par0,lb,ub,fitscale=True)
+    fit2 = fitparamodel(V,mymodel,par0,lb,ub,fitscale=False)
 
     assert all(abs(fit1.param - fit2.param) < 1e-2)
 # =======================================================================
@@ -287,7 +287,7 @@ def test_confinter_values():
                 [1.8953902386010164, 2.322276885466784], 
                 [2.0029218541761944, 2.214745269892137]]
     
-    fit = fitparamodel(y,lambda p: p[0]*x + p[1],[0.1,1],rescale=False)
+    fit = fitparamodel(y,lambda p: p[0]*x + p[1],[0.1,1],fitscale=False)
     a_ci = [fit.uncertainty.ci(cov[i])[0,:] for i in range(3)]
     b_ci = [fit.uncertainty.ci(cov[i])[1,:] for i in range(3)]
 


### PR DESCRIPTION
Renames the `fitparamodel` keyword argument `rescale` to `fitscale`.

Closes #128.