### PR TITLE
Properly implement post-definition manipulations of `UQResult` 

### DIFF
--- a/deerlab/classes.py
+++ b/deerlab/classes.py
@@ -162,12 +162,7 @@ class UQResult:
         return super(UQResult, self).__getattribute__(attr)
     #--------------------------------------------------------------------------------
 
-    def _getbounds(self):
-        return self.__lb, self.__ub
-    def _setbounds(self,lb,ub):
-        self.__lb = lb 
-        self.__ub = ub
-        return
+
     # Parameter distributions
     #--------------------------------------------------------------------------------
     def pardist(self,n):

--- a/deerlab/fitmodel.py
+++ b/deerlab/fitmodel.py
@@ -618,7 +618,7 @@ def fitmodel(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
         if uqanalysis and uq=='covariance':
             # scale CIs accordingly
             Pfit_uq_ = copy.deepcopy(Pfit_uq) # need a copy to avoid infite recursion on next step
-            Pfit_uq.ci = lambda p: Pfit_uq_.ci(p)/Pscale
+            Pfit_uq = Pfit_uq_.propagate(lambda P: P/Pscale,lbm=lbl)
 
         # Get the fitted models
         Kfit,Bfit = multiPathwayModel(parfit)
@@ -627,7 +627,7 @@ def fitmodel(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
         Vmod, Vunmod = calculate_Vmod_Vunmod(parfit,Vfit,Bfit,scales)
 
         if uqanalysis and uq=='covariance':
-            Vfit_uq, Pfit_uq, Bfit_uq, Vmod_uq, Vunmod_uq, paruq_bg, paruq_ex, paruq_dd = splituq(snlls_uq, Pfit, Vfit, Bfit, parfit, Kfit, scales)
+            Vfit_uq, _, Bfit_uq, Vmod_uq, Vunmod_uq, paruq_bg, paruq_ex, paruq_dd = splituq(snlls_uq, Pfit, Vfit, Bfit, parfit, Kfit, scales)
             return fit, Pfit, Vfit, Bfit, Vmod, Vunmod, parfit, Pfit_uq, Vfit_uq, Bfit_uq, Vmod_uq, Vunmod_uq, paruq_bg, paruq_ex, paruq_dd,scales,alphaopt
         else:
             return fit, Pfit, Vfit, Bfit, Vmod, Vunmod, parfit, scales, alphaopt
@@ -696,7 +696,7 @@ def fitmodel(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
         if uqanalysis:
             # scale CIs accordingly
             Pfit_uq_ = copy.deepcopy(Pfit_uq) # need a copy to avoid infite recursion on next step
-            Pfit_uq.ci = lambda p: Pfit_uq_.ci(p)/scale
+            Pfit_uq = Pfit_uq_.propagate(lambda P: P/scale, lbm=np.zeros_like(r))
 
     # Do not return array for a single scale
     if len(scales)==1:

--- a/deerlab/fitmultimodel.py
+++ b/deerlab/fitmultimodel.py
@@ -516,7 +516,7 @@ def fitmultimodel(V, Kmodel, r, model, maxModels, method='aic', lb=None, ub=None
         fitparam_amp = fitparam_amp/sum(fitparam_amp)
         if uq:
             Puq_ = copy.deepcopy(Puq) # need a copy to avoid infite recursion on next step
-            Puq.ci = lambda p: Puq_.ci(p)/postscale
+            Puq = Puq_.propagate(lambda P: P/postscale, lbm=np.zeros_like(Pfit))
 
     # Dataset scales
     scales = []

--- a/deerlab/fitregmodel.py
+++ b/deerlab/fitregmodel.py
@@ -236,7 +236,7 @@ def fitregmodel(V, K, r, regtype='tikhonov', regparam='aic', regorder=2, solver=
         Pfit = Pfit/postscale
         if uq:
             Puq_ = copy.deepcopy(Puq) # need a copy to avoid infite recursion on next step
-            Puq.ci = lambda p: Puq_.ci(p)/postscale
+            Puq = Puq_.propagate(lambda P: P/postscale, lbm=np.zeros_like(Pfit))
 
     # Goodness-of-fit
     # --------------------------------------

--- a/deerlab/snlls.py
+++ b/deerlab/snlls.py
@@ -456,8 +456,8 @@ def snlls(y, Amodel, par0, lb=None, ub=None, lbl=None, ubl=None, nnlsSolver='cvx
         # Split the uncertainty quantification of nonlinear/linear parts
         nonlin_subset = np.arange(0,Nnonlin)
         lin_subset = np.arange(Nnonlin,Nnonlin+Nlin)
-        paramuq_nonlin = uq_subset(paramuq,nonlin_subset)
-        paramuq_lin = uq_subset(paramuq,lin_subset)
+        paramuq_nonlin = uq_subset(paramuq,nonlin_subset,lb,ub)
+        paramuq_lin = uq_subset(paramuq,lin_subset,lbl,ubl)
 
     else:
         paramuq_nonlin = UQResult('void')
@@ -503,23 +503,12 @@ def snlls(y, Amodel, par0, lb=None, ub=None, lbl=None, ubl=None, nnlsSolver='cvx
 # ===========================================================================================
 
 
-def uq_subset(uq_full,subset):
+def uq_subset(uq_full,subset,subset_lb,subset_ub):
 #===========================================================================
-    "Wrapper around the CI function handle of the uncertainty structure"
-    uq_subset = copy.deepcopy(uq_full)
+    "Get the uncertainty quantification for a subset of parameters"
 
-    uq_subset.mean = uq_subset.mean[subset]
-    uq_subset.median = uq_subset.median[subset]
-    uq_subset.std = uq_subset.std[subset]
-    uq_subset.covmat = uq_subset.covmat[np.ix_(subset,subset)]
-    uq_subset.nparam = len(subset)
-    lbsubset = uq_subset._getbounds()[0][subset]
-    ubsubset = uq_subset._getbounds()[1][subset]
-    uq_subset._setbounds(lbsubset,ubsubset)
-
-    # Get requested confidence interval of joined parameter set
-    uq_subset.ci = lambda coverage: uq_full.ci(coverage)[subset, :]
-    uq_subset.percentile = lambda p: uq_full.percentile(p)[subset]
+    subset_model = lambda x: x[subset]
+    uq_subset = uq_full.propagate(subset_model,lbm=subset_lb, ubm=subset_ub)
 
     return uq_subset
 #===========================================================================


### PR DESCRIPTION
This corrects the behavior when performing simple operations such as rescaling or subset separation of uncertainty quantification objects after these have been created. 

Until now only the `ci()` method was being wrapped, leading to all the attributes in the objects being left unchanged. This has repercussions in errors and numerical bugs later when propagating those objects to other functions.