### PR TITLE
Refactor and generalize metadata definition for models

### DIFF
--- a/deerlab/bg_models.py
+++ b/deerlab/bg_models.py
@@ -11,9 +11,10 @@ import inspect
 from deerlab.utils import load_exvolume_redfactor, metadata
 
 
-# Definition of the header for all experiment models taking lambda as well
 # =================================================================
-docstr_header1 = lambda title,fcnstr: f"""
+def docstr_header1(title,fcnstr): 
+    """ Definition of the header for all experiment models taking lambda as well"""
+    return f"""
 {title}
 
 The function takes a list or array of parameters and returns the calculated background model::
@@ -47,9 +48,10 @@ B : ndarray
 """
 # =================================================================
 
-# Definition of the header for all experiment models 
 # =================================================================
-docstr_header2 = lambda title,fcnstr: f"""
+def docstr_header2(title,fcnstr): 
+    """Definition of the header for all experiment models"""
+    return f"""
 {title}
 
 The function takes a list or array of parameters and returns the calculated background model::

--- a/deerlab/bg_models.py
+++ b/deerlab/bg_models.py
@@ -8,7 +8,7 @@ import math as m
 import scipy as scp
 from numpy import pi
 import inspect
-from deerlab.utils import load_exvolume_redfactor
+from deerlab.utils import load_exvolume_redfactor, metadata
 
 
 # Definition of the header for all experiment models taking lambda as well
@@ -99,21 +99,6 @@ def docstring(takes_lambda=False):
 # =================================================================
 
 # =================================================================
-def setmetadata(parameters,units,start,lower,upper):
-    """
-    Decorator: Set model metadata as function attributes 
-    """
-    def _setmetadata(func):
-        func.parameters = parameters
-        func.units = units
-        func.start = start
-        func.lower = lower
-        func.upper = upper
-        return func
-    return _setmetadata
-# =================================================================
-
-# =================================================================
 def _parsargs(t,p,npar):
     t,p = np.atleast_1d(t,p)
     # Check that the correct number of parmameters have been specified
@@ -125,7 +110,7 @@ def _parsargs(t,p,npar):
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Concentration of pumped spins'],
 units = ['μM'],
 start = np.asarray([50]),
@@ -183,7 +168,7 @@ where `c_p` is the pumped-spin concentration (entered in spins/m\ :sup:`3` into 
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Spin concentration','Exclusion distance'],
 units = ['μM','nm'],
 start = np.asarray([50,   1]),
@@ -261,7 +246,7 @@ The function :math:`\alpha(R)` of the exclusion distance :math:`R` captures the 
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Fractal Concentration of pumped spins','Fractal dimensionality'],
 units = ['μmol/dmᵈ',''],
 start = np.asarray([50,   3]),
@@ -321,7 +306,7 @@ This implements the background due to a homogeneous distribution of spins in a d
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Decay Rate'],
 units = ['μs⁻¹'],
 start = np.asarray([0.35]),
@@ -361,7 +346,7 @@ parameter is a decay rate constant and not a spin concentration like for ``bg_ho
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Decay Rate','Stretch factor'],
 units = ['μs⁻¹',''],
 start = np.asarray([0.25, 1]),
@@ -400,7 +385,7 @@ first parameter is a decay rate constant and not a spin concentration like for `
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Decay Rate of 1st component','Stretch factor of 1st component',
               'Decay Rate of 2nd component','Stretch factor of 2nd component'],
 units = ['µs^-1','','µs^-1',''],
@@ -441,7 +426,7 @@ Notes
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Decay Rate of 1st component','Stretch factor of 1st component',
               'Amplitude of 1st component','Decay Rate of 2nd component','Stretch factor of 2nd component'],
 units = ['μs⁻¹','','','μs⁻¹',''],
@@ -484,7 +469,7 @@ Notes
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Intercept','1st-order coefficient'],
 units = ['','μs⁻¹'],
 start = np.asarray([ 1,   -1 ]),
@@ -518,7 +503,7 @@ Notes
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Intercept','1st-order coefficient','2nd-order coefficient'],
 units = ['','μs⁻¹','μs⁻²'],
 start = np.asarray([ 1,   -1 , -1]),
@@ -553,7 +538,7 @@ Notes
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Intercept','1st-order coefficient','2nd-order coefficient','3rd-order coefficient'],
 units = ['','μs⁻¹','μs⁻²','μs⁻³'],
 start = np.asarray([ 1,  -1  , -1,   -1  ]),

--- a/deerlab/dd_models.py
+++ b/deerlab/dd_models.py
@@ -7,6 +7,7 @@ import math as m
 import numpy as np
 import scipy.special as spc
 import inspect
+from deerlab.utils import metadata 
 
 # Definition of the header for all experiment models
 docstr_header = lambda title, fcnstr: f"""
@@ -82,21 +83,6 @@ def docstring():
 # =================================================================
 
 # =================================================================
-def setmetadata(parameters,units,start,lower,upper):
-    """
-    Decorator: Set model metadata as function attributes 
-    """
-    def _setmetadata(func):
-        func.parameters = parameters
-        func.units = units
-        func.start = start
-        func.lower = lower
-        func.upper = upper
-        return func
-    return _setmetadata
-# =================================================================
-
-# =================================================================
 def _parsparam(r,p,npar):
     r,p = np.atleast_1d(r,p)
     if len(p)!=npar:
@@ -139,7 +125,7 @@ def _multirice3dfun(r,nu,sig,a):
 # =================================================================
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Mean','Standard deviation'),
 units = ('nm','nm'),
 start = np.asarray([3.5, 0.2]),
@@ -174,7 +160,7 @@ Variable        Symbol                    Start value    Lower bound    Upper bo
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Mean of 1st Gaussian', 'Standard deviation of 1st Gaussian', 'Amplitude of 1st Gaussian',
                 'Mean of 2nd Gaussian', 'Standard deviation of 2nd Gaussian', 'Amplitude of 2nd Gaussian'),
 units = ('nm','nm','','nm','nm',''),
@@ -215,7 +201,7 @@ Variable         Symbol                  Start Value   Lower bound   Upper bound
     
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Mean of 1st Gaussian', 'Standard deviation of 1st Gaussian', 'Amplitude of 1st Gaussian',
                 'Mean of 2nd Gaussian', 'Standard deviation of 2nd Gaussian', 'Amplitude of 2nd Gaussian',
                 'Mean of 3rd Gaussian', 'Standard deviation of 3rd Gaussian', 'Amplitude of 3rd Gaussian'),
@@ -259,7 +245,7 @@ Variable         Symbol                   Start Value   Lower bound   Upper boun
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Mean','Spread','Kurtosis'),
 units = ('nm','nm',''),
 start = np.asarray([3.5, 0.5,0.5]),
@@ -299,7 +285,7 @@ Variable         Symbol                   Start Value   Lower bound   Upper boun
     
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Center','Spread','Kurtosis'),
 units = ('nm','nm',''),
 start = np.asarray([3.5, 0.2, 5]),
@@ -340,7 +326,7 @@ Variable         Symbol       Start Value   Lower bound   Upper bound      Descr
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Location','Spread'),
 units = ('nm','nm'),
 start = np.asarray([3.5, 0.7]),
@@ -377,7 +363,7 @@ Variable         Symbol                 Start Value   Lower bound   Upper bound 
     
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Location of 1st Rician', 'Spread of 1st Rician', 'Amplitude of 1st Rician',
                 'Location of 2nd Rician', 'Spread of 2nd Rician', 'Amplitude of 2nd Rician'),
 units = ('nm','nm','','nm','nm',''),
@@ -422,7 +408,7 @@ Variable         Symbol                 Start Value   Lower bound   Upper bound 
     
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Location of 1st Rician', 'Spread of 1st Rician', 'Amplitude of 1st Rician',
               'Location of 2nd Rician', 'Spread of 2nd Rician', 'Amplitude of 2nd Rician',
               'Location of 3rd Rician', 'Spread of 3rd Rician', 'Amplitude of 3rd Rician'),
@@ -471,7 +457,7 @@ Variable         Symbol                 Start Value   Lower bound   Upper bound 
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Number of residues','Segment length','Scaling exponent'),
 units = ('','nm',''),
 start = np.asarray([50,   0.2, 0.602]),
@@ -519,7 +505,7 @@ Variable         Symbol       Start Value   Lower bound   Upper bound      Descr
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Center','Radius'),
 units = ('nm','nm'),
 start = np.asarray([3, 0.5]),
@@ -558,7 +544,7 @@ Variable         Symbol          Start Value   Lower bound   Upper bound      De
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Center','FWHM'),
 units = ('nm','nm'),
 start = np.asarray([3, 0.5]),
@@ -630,7 +616,7 @@ def _pbs(r,R1,R2):
 # =================================================================
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Inner shell radius','Shell thickness'),
 units = ('nm','nm'),
 lower = np.asarray([0.1, 0.1]),
@@ -692,7 +678,7 @@ References
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Sphere radius','Distance to point'),
 units = ('nm','nm'),
 lower = np.asarray([0.1, 0.1]),
@@ -737,7 +723,7 @@ References
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Sphere radius',),
 units = ('nm',),
 lower = np.asarray([0.1]),
@@ -780,7 +766,7 @@ References
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Inner shell radius','1st Shell thickness','2nd Shell thickness'),
 units = ('nm','nm','nm'),
 lower = np.asarray([0.1, 0.1, 0.1]),
@@ -851,7 +837,7 @@ References
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Sphere radius','Shell thickness'),
 units = ('nm','nm'),
 lower = np.asarray([0.1, 0.1]),
@@ -902,7 +888,7 @@ References
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Sphere radius','1st Shell thickness','2nd Shell thickness','Shell-Shell separation'),
 units = ('nm','nm','nm','nm'),
 lower = np.asarray([0.1, 0.1, 0.1, 0.1]),
@@ -982,7 +968,7 @@ References
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Sphere radius','Shell thickness','Shell-Sphere separation'),
 units = ('nm','nm','nm'),
 lower = np.asarray([0.1, 0.1, 0.1]),
@@ -1051,7 +1037,7 @@ References
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Sphere radius',),
 units = ('nm',),
 lower = np.asarray([0.1]),
@@ -1092,7 +1078,7 @@ References
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Mode','Left width','Right width'),
 units = ('nm','nm','nm'),
 lower = np.asarray([1, 0.1, 0.1]),
@@ -1137,7 +1123,7 @@ Variable         Symbol                 Start Value   Lower bound   Upper bound 
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Left edge','Right edge'),
 units = ('nm','nm'),
 lower = np.asarray([0.1, 0.2]),
@@ -1193,7 +1179,7 @@ def wlc(r,L,Lp):
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Contour length','Persistence length'),
 units = ('nm','nm'),
 lower = np.asarray([1.5, 2]),
@@ -1232,7 +1218,7 @@ References
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ('Contour length','Persistence length','Gaussian standard deviation'),
 units = ('nm','nm','nm'),
 lower = np.asarray([1.5, 2, 0.001]),

--- a/deerlab/dd_models.py
+++ b/deerlab/dd_models.py
@@ -9,8 +9,10 @@ import scipy.special as spc
 import inspect
 from deerlab.utils import metadata 
 
-# Definition of the header for all experiment models
-docstr_header = lambda title, fcnstr: f"""
+# =================================================================
+def docstr_header(title,fcnstr):
+    "Definition of the header for all distribution models"
+    return f"""
 {title}
 
 The function takes a list or array of parameters and returns the calculated distance distribution::
@@ -39,8 +41,12 @@ Returns
 P : ndarray
     Distance distribution.
 """
+# =================================================================
 
-docstr_example = lambda fcnstr: f""" 
+
+# =================================================================
+def docstr_example(fcnstr): 
+    return f""" 
 Examples
 --------
 
@@ -65,6 +71,8 @@ Example of the model evaluated at the start values of the parameters:
     plt.tick_params(labelsize=12)
     plt.tight_layout()
 """
+# =================================================================
+
 
 # =================================================================
 def docstring():

--- a/deerlab/ex_models.py
+++ b/deerlab/ex_models.py
@@ -6,8 +6,10 @@
 import numpy as np
 from deerlab.utils import metadata 
 
-# Definition of the header for all experiment models
-docstr_header = lambda title,fcnstr: f"""
+# =================================================================
+def docstr_header(title,fcnstr):
+    "Definition of the header for all experiment models"
+    return f"""
 {title}
 
 The function takes a list or array of parameters and returns the calculated experiment dipolar pathways::
@@ -32,7 +34,8 @@ Returns
     
 pathways : ndarray
     Dipolar pathways of the experiment
-"""
+    """
+# =================================================================
 
 # =================================================================
 def docstring():

--- a/deerlab/ex_models.py
+++ b/deerlab/ex_models.py
@@ -4,7 +4,7 @@
 # Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
 
 import numpy as np
-
+from deerlab.utils import metadata 
 
 # Definition of the header for all experiment models
 docstr_header = lambda title,fcnstr: f"""
@@ -49,22 +49,6 @@ def docstring():
     return _decorator
 # =================================================================
 
-
-# =================================================================
-def setmetadata(parameters,units,start,lower,upper):
-    """
-    Decorator: Set model metadata as function attributes 
-    """
-    def _setmetadata(func):
-        func.parameters = parameters
-        func.units = units
-        func.start = start
-        func.lower = lower
-        func.upper = upper
-        return func
-    return _setmetadata
-# =================================================================
-
 #=================================================================
 def _parsargs(param,npar):
     param = np.atleast_1d(param)
@@ -75,7 +59,7 @@ def _parsargs(param,npar):
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Modulation depth'],
 units = [''],
 start = np.asarray([0.3]),
@@ -119,7 +103,7 @@ where :math:`T_0^{(1)}=0` is the refocusing time of the modulated dipolar pathwa
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Amplitude of unmodulated components','Amplitude of 1st modulated pathway',
                 'Amplitude of 2nd modulated pathway','Refocusing time of 2nd modulated pathway'],
 units = ['','','','μs'],
@@ -170,7 +154,7 @@ where :math:`T_0^{(1)}=0` and :math:`T_0^{(2)}` are the refocusing times of the 
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Amplitude of unmodulated components','Amplitude of 1st modulated pathway','Amplitude of 2nd modulated pathway','Refocusing time of 2nd modulated pathway'],
 units = ['','','','μs'],
 start = np.asarray([0.4, 0.4, 0.2,5]),
@@ -219,7 +203,7 @@ where :math:`T_0^{(1)}=0` and :math:`T_0^{(2)}` are the refocusing times of the 
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Amplitude of unmodulated components','Amplitude of 1st modulated pathway',
                 'Amplitude of 2nd modulated pathway','Amplitude of 3rd modulated pathway',
                 'Refocusing time of 2nd modulated pathway','Refocusing time of 3rd modulated pathway'],
@@ -274,7 +258,7 @@ where :math:`T_0^{(1)}=0\;\mu s`, :math:`T_0^{(2)}`, and :math:`T_0^{(3)}` are t
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Amplitude of unmodulated contribution','Amplitude of 1st modulated pathway'],
 units = ['',''],
 start = np.asarray([0.3, 0.5]),
@@ -315,7 +299,7 @@ This experiment model has one harmonic pathway and an unmodulated contribution. 
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Amplitude of unmodulated contribution','Amplitude of 1st harmonic pathway',
                 'Amplitude of 2nd harmonic pathway','Amplitude of 3rd harmonic pathway'],
 units = ['','','',''],
@@ -362,7 +346,7 @@ This experiment model has three harmonic pathways and an unmodulated contributio
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Amplitude of unmodulated contribution','Amplitude of 1st harmonic pathway',
                 'Amplitude of 2nd harmonic pathway','Amplitude of 3rd harmonic pathway',
                 'Amplitude of 4th harmonic pathway','Amplitude of 5th harmonic pathway'],
@@ -413,7 +397,7 @@ This experiment model has five harmonic pathways and an unmodulated contribution
 
 
 # =================================================================
-@setmetadata(
+@metadata(
 parameters = ['Amplitude of unmodulated contribution','Amplitude of 1st harmonic pathway',
                 'Amplitude of 2nd harmonic pathway','Amplitude of 3rd harmonic pathway',
                 'Amplitude of 4th harmonic pathway','Amplitude of 5th harmonic pathway',

--- a/deerlab/utils/utils.py
+++ b/deerlab/utils/utils.py
@@ -212,6 +212,21 @@ def hccm(J,*args):
 #===============================================================================
 
 
+# =================================================================
+def metadata(**kwargs):
+    """
+    Decorator: Set model metadata as function attributes 
+    """
+    attributes = list(kwargs.keys())
+    metadata = list(kwargs.values())
+
+    def _setmetadata(func):
+        for attribute,data in zip(attributes,metadata):
+            setattr(func,attribute,data)
+        return func
+    return _setmetadata
+# =================================================================
+
 def gsvd(A,B):
 #===============================================================================
     m,p = A.shape


### PR DESCRIPTION
### Changelog: 
- Generalize the `setmetadata()` decorator ( defined in all models modules, repeated trice) into a new decorator `metadata()` in the `deerlab.utils` module. Remove the repeated old function. 
- Redefine the docstring headers of the models as typed functions rather than lambda functions.