### PR TITLE
Distribute DeerLab via Anaconda 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ DeerLab.egg-info/dependency_links.txt
 DeerLab.egg-info/SOURCES.txt
 DeerLab.egg-info/PKG-INFO
 */dist/*
-*/build*
+*/build/*
 /.venv/*
 target/
 docsrc/source/.doctrees

--- a/conda.recipe/build.bat
+++ b/conda.recipe/build.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "v0.12.2" %}
+
+package:
+  name: deerlab
+  version: {{ version }}
+
+source:
+  git_rev: {{ version }}
+  git_url: https://github.com/JeschkeLab/DeerLab.git
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - memoization
+    - matplotlib
+    - tqdm
+    - joblib
+    - numpy
+    - scipy
+    - cvxopt
+
+about:
+  home: https://jeschkelab.github.io/DeerLab/index.html
+  license: MIT
+  summary: 'Comprehensive package for data analysis of dipolar EPR spectroscopy'
+  description: |
+    DeerLab is a Python package for the analysis of dipolar EPR (electron paramagnetic resonance)
+    spectroscopy data. Dipolar EPR spectroscopy techniques include DEER (double electron-electron resonance),
+    RIDME (relaxation-induced dipolar modulation enhancement), and others.
+    DeerLab consists of a collection of functions for modelling, data processing, and least-squares fitting.
+    They can be combined in scripts to build custom data analysis workflows. DeerLab supports both classes of 
+    distance distribution models: non-parametric (Tikhonov regularization and related) and parametric 
+    (multi-Gaussians etc). It also provides a selection of background and experiment models.
+  dev_url: https://jeschkelab.github.io/DeerLab

--- a/conda.recipe/package_conda.bat
+++ b/conda.recipe/package_conda.bat
@@ -1,0 +1,44 @@
+@echo off
+
+set versions=3.6 3.7 3.8
+set platforms=osx-64 linux-32 linux-64 win-32 win-64
+
+:: Get the path to the Anaconda executable
+for %%i in (_conda.exe) do (
+    set anaconda=%%~p$PATH:i
+)
+set conda_build=C:%anaconda%conda-bld
+
+echo Activating Anaconda environment...
+Powershell.exe -executionpolicy remotesigned C:%anaconda%shell\condabin\conda-hook.ps1 ; conda activate 'C:%anaconda%'
+
+echo Activating Anaconda client...
+call anaconda login
+
+echo Building conda package...
+:: Delete existing tarball files 
+for %%f in (%conda_build%\win-64\*.tar.bz2) do (
+    del %%f
+)
+
+:: Build  the conda packages for the supported Python versions
+for %%v in (%versions%) do (
+    call conda-build --python %%v .
+)
+
+:: Convert packages to all supported platforms
+for %%f in (%conda_build%\win-64\*.tar.bz2) do (
+    echo "Converting %%f"
+    for %%p in (%platforms%) do (
+        call conda-convert --platform %%p %%f  -o %conda_build%
+    )
+)
+
+:: Upload packages to Anaconda
+for %%p in (%platforms%) do (
+    for %%f in (%conda_build%\%%p\*.tar.bz2) do (
+        call anaconda upload --user JeschkeLab %%f
+    )
+)
+
+echo "Building conda package finished!"


### PR DESCRIPTION
Thanks to the help of @mtessmer we have been able to setup the packaging of DeerLab via `conda`. 

I have implemented the automated packaging and distribution of DeerLab via the Anaconda repo. 

The package is distributed via the `JeschkeLab` channel in Anaconda.