### PR TITLE
snlls: allow `extrapenalty` to take linear parameters as input

### DIFF
--- a/deerlab/fitmodel.py
+++ b/deerlab/fitmodel.py
@@ -568,7 +568,7 @@ def fitmodel(Vexp, t, r, dd_model='P', bg_model=bg_hom3d, ex_model=ex_4pdeer,
         prescales = [1 for V in Vexp]
         Vexp_ = [Vexp[i]/prescales[i] for i in range(nSignals)]
 
-        def scale_constraint(nonlinpar):
+        def scale_constraint(nonlinpar,linpar):
         # --------------------------------------------------------
             penalty = np.zeros(nSignals)
             for i in range(nSignals):

--- a/deerlab/snlls.py
+++ b/deerlab/snlls.py
@@ -436,10 +436,10 @@ def snlls(y, Amodel, par0, lb=None, ub=None, lbl=None, ubl=None, nnlsSolver='cvx
 
         # Jacobian (linear part)
         Jlin = scales_vec[:,np.newaxis]*Amodel(nonlinfit)
+        if callable(extrapenalty):
+            Jlin = np.concatenate((Jlin, Jacobian(lambda plin: extrapenalty(nonlinfit,plin),linfit,lbl,ubl)))
         if includeRegularization:
             Jlin = np.concatenate((Jlin, reg_penalty(regtype, alpha, L, linfit, huberparam, Nnonlin)[1]))
-        if callable(extrapenalty):
-            Jlin = np.concatenate((Jlin, Jacobian(lambda plin:extrapenalty(nonlinfit,plin),linfit,lbl,ubl)))
 
         # Full Jacobian
         J = np.concatenate((Jnonlin,Jlin),axis=1)

--- a/deerlab/snlls.py
+++ b/deerlab/snlls.py
@@ -87,9 +87,10 @@ def snlls(y, Amodel, par0, lb=None, ub=None, lbl=None, ubl=None, nnlsSolver='cvx
         The regularization parameter can be manually specified by passing a scalar value
         instead of a string. The default ``'aic'``.
 
-    custom_penalty: callable 
-        Custom penalty function to impose upon the solution. Must return a vector to be
-        added to the residual vector. 
+    extrapenalty: callable 
+        Custom penalty function to impose upon the solution. Must take two inputs, a vector of non-linear parameters
+        and a vector of linear parameters, and return a vector to be added to the residual vector (``pen = fcn(pnonlin,plin)``).  
+        The square of the penalty is computed internally.
 
     alphareopt : float scalar, optional
         Relative parameter change threshold for reoptimizing the regularization parameter
@@ -383,7 +384,7 @@ def snlls(y, Amodel, par0, lb=None, ub=None, lbl=None, ubl=None, nnlsSolver='cvx
 
         # Compute residual from custom penalty
         if callable(extrapenalty):
-            penres = extrapenalty(p)
+            penres = extrapenalty(p,linfit)
             penres = np.atleast_1d(penres)
             res = np.concatenate((res,penres))
 
@@ -434,10 +435,11 @@ def snlls(y, Amodel, par0, lb=None, ub=None, lbl=None, ubl=None, nnlsSolver='cvx
         Jnonlin = Jacobian(ResidualsFcn,nonlinfit,lb,ub)
 
         # Jacobian (linear part)
-        Jlin = np.zeros((len(res),len(linfit)))
-        Jlin[:len(y),:] = scales_vec[:,np.newaxis]*Amodel(nonlinfit)
+        Jlin = scales_vec[:,np.newaxis]*Amodel(nonlinfit)
         if includeRegularization:
-            Jlin[len(res)-Nlin:,:] = reg_penalty(regtype, alpha, L, linfit, huberparam, Nnonlin)[1]
+            Jlin = np.concatenate((Jlin, reg_penalty(regtype, alpha, L, linfit, huberparam, Nnonlin)[1]))
+        if callable(extrapenalty):
+            Jlin = np.concatenate((Jlin, Jacobian(lambda plin:extrapenalty(nonlinfit,plin),linfit,lbl,ubl)))
 
         # Full Jacobian
         J = np.concatenate((Jnonlin,Jlin),axis=1)


### PR DESCRIPTION
The optional argument `extrapenalty` allows the specification of custom penalties to be added to the residual vector in `snlls`. However, at the moment it only takes nonlinear parameters as an input. This PR enhances the functionality to allow also to define penalties depending on the linear parameters. 

The new syntax takes two positional arguments for the penalty function: 
```python
def penaltyfcn(pnonlin,plin):
      ...
      return penvector
fit = dl.snlls(..., extrapenalty=penaltyfcn)
```

It also fixes an error in the documentation of `snlls` where `extrapenalty`  argument is listed as `custom_penalty`.