### PR TITLE
`dipolarkernel`: Implement orientation selection dipolar kernels

### DIFF
--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -16,14 +16,14 @@ from memoization import cached
 # DeerLab dependencies
 from deerlab.dipolarbackground import dipolarbackground
 
-π = np.pi 
 # Fundamental constants (CODATA 2018)
+π = np.pi 
 ge = 2.00231930436256 # free-electron g factor
-muB = 9.2740100783e-24 # Bohr magneton, J/T 
-mu0 = 1.25663706212e-6 # magnetic constant, N A^-2 = T^2 m^3 J^-1 
-h = 6.62607015e-34 # Planck constant, J/Hz
+μB = 9.2740100783e-24 # Bohr magneton, J/T 
+μ0 = 1.25663706212e-6 # magnetic constant, N A^-2 = T^2 m^3 J^-1 
+h  = 6.62607015e-34   # Planck constant, J/Hz
 def ω0(g):
-    return (mu0/2)*muB**2*g[0]*g[1]/h*1e21 # Hz m^3 -> MHz nm^3 -> Mrad s^-1 nm^3
+    return (μ0/2)*μB**2*g[0]*g[1]/h*1e21 # Hz m^3 -> MHz nm^3 -> rad μs^-1 nm^3
 
 def dipolarkernel(t, r, *, pathways=None, mod=None, bg=None, method='fresnel', excbandwidth=inf, orisel=None, g=[ge,ge], 
                   integralop=True, nKnots=5001, clearcache=False):
@@ -221,7 +221,7 @@ def dipolarkernel(t, r, *, pathways=None, mod=None, bg=None, method='fresnel', e
     if integralop and len(r)>1:
             
         # Vectorized matrix form of trapezoidal integration method
-        dr = np.zeros(len(r))
+        dr = np.zeros_like(r)
         dr[0] = r[1] - r[0]
         dr[-1] = r[-1] - r[-2]
         dr[1:-1] = r[2:] - r[0:-2]
@@ -255,7 +255,7 @@ def elementarykernel(t,r,method,ωex,nKnots,g,Pθ=None):
     nr = np.size(r)
     nt = np.size(t)  
     K = np.zeros((nt,nr))
-    ωr = ω0(g)/(r**3)  # Mrad s^-1
+    ωr = ω0(g)/(r**3)  # rad μs^-1
 
     orientationselection = Pθ is not None 
 

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -311,18 +311,18 @@ def elementarykernel(t,r,method,ωex,nKnots,g,Pθ):
         if orientationselection:
             Pθnorm,_ = scipy.integrate.quad(lambda cosθ: Pθ(np.arccos(cosθ)),0,1,limit=1000)
         for ir in range(len(ωr)):
-            for it in range(len(t)):
                 #==================================================================
                 def integrand(cosθ):
-                    integ = np.cos(ωr[ir]*abs(t[it])*(1-3*cosθ**2))
+                integ = np.cos(ωr[ir]*abs(t)*(1-3*cosθ**2))
                     # If given, include limited excitation bandwidth
                     if not np.isinf(ωex):
                         integ = integ*np.exp(-(ωr[ir]*(1-3*cosθ**2))**2/ωex**2)
+                # If given, include orientation selection
                     if orientationselection:
-                        integ = integ*Pθ(np.arccos(cosθ))/Pθnorm  
+                    integ = integ*Pθ(np.arccos(cosθ))  
                     return integ
                 #==================================================================   
-                K0[it,ir],_ = scipy.integrate.quad(integrand,0,1,limit=1000)
+            K0[:,ir],_ = scipy.integrate.quad_vec(integrand,0,1,limit=1000)
         return K0
     #==========================================================================
 

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -145,7 +145,7 @@ def dipolarkernel(t, r, *, pathways=None, mod=None, bg=None, method='fresnel', e
     # Clear cache of memoized function is requested
     if clearcache:
         elementarykernel.cache_clear()
-        _Cgrid.cache.clear()
+        _Cgrid.cache_clear()
 
     # Ensure that inputs are Numpy arrays
     r,t,g = np.atleast_1d(r,t,g)

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -150,6 +150,9 @@ def dipolarkernel(t, r, *, pathways=None, mod=None, bg=None, method='fresnel', e
     if np.any(r<=0):
         raise ValueError("All elements in r must be nonnegative and nonzero.")
 
+    # Check that the kernel construction method is compatible with requested options
+    if excbandwidth != inf and method=='fresnel':
+        raise KeyError("Excitation bandwidths can only be specified with the 'grid' or 'integral' methods.")
     # Check whether the full pathways or the modulation depth have been passed
     pathways_passed =  pathways is not None
     moddepth_passed =  mod is not None

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -65,7 +65,7 @@ def dipolarkernel(t, r, *, pathways=None, mod=None, bg=None, method='fresnel', e
     orisel : callable  or ``None``, optional 
         Probability distribution of possible orientations of the interspin vector to account for orientation selection. Must be 
         a function taking a value of the angle θ∈[0,π/2] between the interspin vector and the external magnetic field and returning
-        the corresponding probability density. If speficied as ``None`` (by default), a uniform distribution is assumed. 
+        the corresponding probability density. If specified as ``None`` (by default), a uniform distribution is assumed. 
         Requires the ``'grid'`` or ``'integral'`` methods.
 
     excbandwidth : scalar, optional

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -230,9 +230,9 @@ def dipolarkernel(t, r, *, pathways=None, mod=None, bg=None, method='fresnel', e
     return K
 #==============================================================================
 
-@cached
-#==============================================================================
+@cached(max_size=5)
 def _Cgrid(ωr,t,ωex,q):
+#==============================================================================
     "Evaluates the costly 3D powder kernel matrix (cached for speed)"
     # Vectorized 3D-grid evaluation (t,r,powder averaging)
     C = np.cos(ωr[np.newaxis,:,np.newaxis]*q[np.newaxis,np.newaxis,:]*abs(t[:,np.newaxis,np.newaxis]))
@@ -242,7 +242,7 @@ def _Cgrid(ωr,t,ωex,q):
     return C
 #==============================================================================
 
-@cached
+@cached(max_size=100)
 def elementarykernel(t,r,method,ωex,nKnots,g,Pθ=None):
 #==============================================================================
     "Calculates the elementary dipolar kernel (cached for speed)"

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -182,7 +182,8 @@ def dipolarkernel(t, r, *, pathways=None, mod=None, bg=None, method='fresnel', e
         pathways = [[1, 0]]
 
     # Ensure correct formatting of the pathways
-    paths = [np.concatenate([np.atleast_1d(p) for p in path]).astype(float) for path in pathways]
+    paths = [np.atleast_1d(path).astype(float) for path in pathways]
+    paths = [np.concatenate([np.atleast_1d(p) for p in path]).astype(float) for path in paths]
 
     # Get unmodulated pathways    
     unmodulated = [paths.pop(i) for i,path in enumerate(paths) if len(path)==1]

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -245,7 +245,7 @@ def _Cgrid(ωr,t,ωex,q):
 #==============================================================================
 
 @cached(max_size=100)
-def elementarykernel(t,r,method,ωex,nKnots,g,Pθ=None):
+def elementarykernel(t,r,method,ωex,nKnots,g,Pθ):
 #==============================================================================
     "Calculates the elementary dipolar kernel (cached for speed)"
 
@@ -291,7 +291,9 @@ def elementarykernel(t,r,method,ωex,nKnots,g,Pθ=None):
 
         if orientationselection:
             # Evaluate orientational distribution over grid        
+            Pθnorm,_ = scipy.integrate.quad(lambda z: Pθ(np.arccos(z)),0,1,limit=1000)
             Pθgrid = Pθ(θ)
+            Pθgrid = Pθgrid/Pθnorm
             # Integrate over the orientations distribution Pθ
             K = np.dot(_Cgrid(ωr,t,ωex,q),Pθgrid)/nKnots
         else: 
@@ -303,6 +305,8 @@ def elementarykernel(t,r,method,ωex,nKnots,g,Pθ=None):
     def elementarykernel_integral(t,ωex,Pθ):
     #==========================================================================
         """Calculate kernel using explicit numerical integration """
+        if orientationselection:
+            Pθnorm,_ = scipy.integrate.quad(lambda cosθ: Pθ(np.arccos(cosθ)),0,1,limit=1000)
         for ir in range(len(ωr)):
             for it in range(len(t)):
                 #==================================================================
@@ -312,7 +316,7 @@ def elementarykernel(t,r,method,ωex,nKnots,g,Pθ=None):
                     if not np.isinf(ωex):
                         integ = integ*np.exp(-(ωr[ir]*(1-3*cosθ**2))**2/ωex**2)
                     if orientationselection:
-                        integ = integ*Pθ(np.arccos(cosθ))  
+                        integ = integ*Pθ(np.arccos(cosθ))/Pθnorm  
                     return integ
                 #==================================================================   
                 K[it,ir],_ = scipy.integrate.quad(integrand,0,1,limit=1000)

--- a/test/test_dipolarkernel.py
+++ b/test/test_dipolarkernel.py
@@ -204,7 +204,7 @@ def test_multipath():
 
     Kref = 1-prob
     for p in range(len(lam)):
-            Kref = Kref + lam[p]*elementarykernel(t-T0[p],r,'fresnel',[],[],[ge,ge])
+            Kref = Kref + lam[p]*elementarykernel(t-T0[p],r,'fresnel',[],[],[ge,ge],None)
 
     assert np.all(abs(K-Kref) < 1e-3)
 #=======================================================================
@@ -228,7 +228,7 @@ def test_multipath_background():
     # Reference
     Kref = 1-prob
     for p in range(len(lam)):
-            Kref = Kref + lam[p]*elementarykernel(t-T0[p],r,'fresnel',[],[],[ge,ge])
+            Kref = Kref + lam[p]*elementarykernel(t-T0[p],r,'fresnel',[],[],[ge,ge],None)
     Kref = Kref
     
     Bref = 1
@@ -272,7 +272,7 @@ def test_multipath_harmonics():
 
     Kref = 1-prob
     for p in range(len(lam)):
-            Kref = Kref + lam[p]*elementarykernel(n[p]*(t-T0[p]),r,'fresnel',[],[],[ge,ge])
+            Kref = Kref + lam[p]*elementarykernel(n[p]*(t-T0[p]),r,'fresnel',[],[],[ge,ge],None)
     Kref = Kref
 
     assert np.max(K-Kref) < 1e-3
@@ -404,12 +404,12 @@ def test_orisel_uni_grid():
 #=======================================================================
     "Check that orientation selection works for a uniform distribution"
 
-    t = np.linspace(0,5,50) 
-    r = np.linspace(2,6,70)
+    t = 1
+    r = 1
     Ptheta = lambda theta: np.ones_like(theta)
 
-    Kref = dipolarkernel(t,r,method='grid',nKnots=100)
-    K = dipolarkernel(t,r,method='grid',nKnots=100,orisel=Ptheta)
+    Kref = dipolarkernel(t,r,method='grid',nKnots=1e5)
+    K = dipolarkernel(t,r,method='grid',nKnots=1e5,orisel=Ptheta)
     
     assert np.max(K - Kref) < 1e-10
 #=======================================================================
@@ -418,8 +418,8 @@ def test_orisel_uni_integral():
 #=======================================================================
     "Check that orientation selection works for a uniform distribution"
 
-    t = np.linspace(0,5,20) 
-    r = np.linspace(2,6,20)
+    t = 1
+    r = 1
     Ptheta = lambda theta: np.ones_like(theta)
 
     Kref = dipolarkernel(t,r,method='integral')
@@ -440,9 +440,9 @@ def test_orisel_value_grid():
 
     # Kernel value for 1us and 1nm computed using Mathematica
     # and CODATA 2018 values for ge, muB, mu0, and h
-    Kref = 0.007128655802119539
+    Kref = 0.02031864642707554
 
-    K = dipolarkernel(t,r,method='grid',nKnots=5e6,orisel=Ptheta)
+    K = dipolarkernel(t,r,method='grid',nKnots=1e7,orisel=Ptheta)
     print(K/Kref)
     assert abs(K - Kref) < 1e-7
 #=======================================================================
@@ -459,7 +459,7 @@ def test_orisel_value_integral():
 
     # Kernel value for 1us and 1nm computed using Mathematica
     # and CODATA 2018 values for ge, muB, mu0, and h
-    Kref = 0.007128655802119539
+    Kref = 0.02031864642707554
 
     K = dipolarkernel(t,r,method='integral',orisel=Ptheta)
     

--- a/test/test_dipolarkernel.py
+++ b/test/test_dipolarkernel.py
@@ -444,7 +444,7 @@ def test_orisel_value_grid():
 
     K = dipolarkernel(t,r,method='grid',nKnots=1e7,orisel=Ptheta)
     print(K/Kref)
-    assert abs(K - Kref) < 1e-7
+    assert abs(K - Kref) < 1e-4
 #=======================================================================
 
 def test_orisel_value_integral():
@@ -463,5 +463,5 @@ def test_orisel_value_integral():
 
     K = dipolarkernel(t,r,method='integral',orisel=Ptheta)
     
-    assert abs(K - Kref) < 1e-10
+    assert abs(K - Kref) < 1e-4
 #=======================================================================

--- a/test/test_dipolarkernel.py
+++ b/test/test_dipolarkernel.py
@@ -400,18 +400,68 @@ def test_nonuniform_r():
     assert np.round(V0,3) == 1
 #=======================================================================
 
-def test_orisel():
+def test_orisel_uni_grid():
 #=======================================================================
-    "Check that orientation selection works"
+    "Check that orientation selection works for a uniform distribution"
 
     t = np.linspace(0,5,50) 
     r = np.linspace(2,6,70)
-
-    theta = np.linspace(0,90,100)
-    weights = np.ones_like(theta)
+    Ptheta = lambda theta: np.ones_like(theta)
 
     Kref = dipolarkernel(t,r,method='grid',nKnots=100)
-    K = dipolarkernel(t,r,method='grid',nKnots=100,orisel=weights)
+    K = dipolarkernel(t,r,method='grid',nKnots=100,orisel=Ptheta)
     
     assert np.max(K - Kref) < 1e-10
+#=======================================================================
+
+def test_orisel_uni_integral():
+#=======================================================================
+    "Check that orientation selection works for a uniform distribution"
+
+    t = np.linspace(0,5,20) 
+    r = np.linspace(2,6,20)
+    Ptheta = lambda theta: np.ones_like(theta)
+
+    Kref = dipolarkernel(t,r,method='integral')
+    K = dipolarkernel(t,r,method='integral',orisel=Ptheta)
+    
+    assert np.max(K - Kref) < 1e-10
+#=======================================================================
+
+def test_orisel_value_grid():
+#=======================================================================
+    "Check that orientation selection works for a uniform distribution"
+
+    t = 1
+    r = 1
+    thetamean = pi/4
+    sigma = pi/3
+    Ptheta = lambda theta: 1/sigma/np.sqrt(2*pi)*np.exp(-(theta-thetamean)**2/2/sigma**2)
+
+    # Kernel value for 1us and 1nm computed using Mathematica
+    # and CODATA 2018 values for ge, muB, mu0, and h
+    Kref = 0.007128655802119539
+
+    K = dipolarkernel(t,r,method='grid',nKnots=5e6,orisel=Ptheta)
+    print(K/Kref)
+    assert abs(K - Kref) < 1e-7
+#=======================================================================
+
+def test_orisel_value_integral():
+#=======================================================================
+    "Check that orientation selection works for a uniform distribution"
+
+    t = 1
+    r = 1
+    thetamean = pi/4
+    sigma = pi/3
+    Ptheta = lambda theta: 1/sigma/np.sqrt(2*pi)*np.exp(-(theta-thetamean)**2/2/sigma**2)
+
+    # Kernel value for 1us and 1nm computed using Mathematica
+    # and CODATA 2018 values for ge, muB, mu0, and h
+    Kref = 0.007128655802119539
+
+    K = dipolarkernel(t,r,method='integral',orisel=Ptheta)
+    
+    assert abs(K - Kref) < 1e-10
 #=======================================================================

--- a/test/test_dipolarkernel.py
+++ b/test/test_dipolarkernel.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy import pi, inf, NaN
 from deerlab.bg_models import bg_hom3d,bg_exp
 from deerlab.dd_models import dd_gauss
-from deerlab.dipolarkernel import dipolarkernel,calckernelmatrix
+from deerlab.dipolarkernel import dipolarkernel,elementarykernel
 ge = 2.00231930436256 # free-electron g factor
 
 
@@ -204,7 +204,7 @@ def test_multipath():
 
     Kref = 1-prob
     for p in range(len(lam)):
-            Kref = Kref + lam[p]*calckernelmatrix(t-T0[p],r,'fresnel',[],[],[ge,ge])
+            Kref = Kref + lam[p]*elementarykernel(t-T0[p],r,'fresnel',[],[],[ge,ge])
 
     assert np.all(abs(K-Kref) < 1e-3)
 #=======================================================================
@@ -228,7 +228,7 @@ def test_multipath_background():
     # Reference
     Kref = 1-prob
     for p in range(len(lam)):
-            Kref = Kref + lam[p]*calckernelmatrix(t-T0[p],r,'fresnel',[],[],[ge,ge])
+            Kref = Kref + lam[p]*elementarykernel(t-T0[p],r,'fresnel',[],[],[ge,ge])
     Kref = Kref
     
     Bref = 1
@@ -272,7 +272,7 @@ def test_multipath_harmonics():
 
     Kref = 1-prob
     for p in range(len(lam)):
-            Kref = Kref + lam[p]*calckernelmatrix(n[p]*(t-T0[p]),r,'fresnel',[],[],[ge,ge])
+            Kref = Kref + lam[p]*elementarykernel(n[p]*(t-T0[p]),r,'fresnel',[],[],[ge,ge])
     Kref = Kref
 
     assert np.max(K-Kref) < 1e-3

--- a/test/test_dipolarkernel.py
+++ b/test/test_dipolarkernel.py
@@ -399,3 +399,19 @@ def test_nonuniform_r():
     V0 = K@P
     assert np.round(V0,3) == 1
 #=======================================================================
+
+def test_orisel():
+#=======================================================================
+    "Check that orientation selection works"
+
+    t = np.linspace(0,5,50) 
+    r = np.linspace(2,6,70)
+
+    theta = np.linspace(0,90,100)
+    weights = np.ones_like(theta)
+
+    Kref = dipolarkernel(t,r,method='grid',nKnots=100)
+    K = dipolarkernel(t,r,method='grid',nKnots=100,orisel=weights)
+    
+    assert np.max(K - Kref) < 1e-10
+#=======================================================================


### PR DESCRIPTION
Introduces a new keyword to `dipolarkernel` that allows passing a distribution of weights for each `theta` value in the powder averaging of the kernel. 

Optimizes the caching of the grid evaluation of the kernel to allow a fast evaluation of the kernel with the same `t` and `r` but different orientation weights. 

Also closes #181.