### PR TITLE
docs: remove absence of orientation selection from DeerLab's assumptions

### DIFF
--- a/docsrc/source/theory.rst
+++ b/docsrc/source/theory.rst
@@ -18,7 +18,6 @@ The theory underlying DeerLab is not fully general and makes a series of assumpt
 6. The dipolar coupling between spins is in the weak-coupling regime, i.e. it is weaker than the difference between their resonance frequencies. Intermediate- and strong-coupling regimes are not handled by DeerLab.
 7. All spins relax with the same phase memory time. Systems with rotamer-specific relaxation rates are not handled by DeerLab.
 8. The signal is free of modulations due to hyperfine couplings (ESEEM).
-9. There is no orientation selection in the experiment. Orientation-selective DEER is not handled by DeerLab.
 
 .. warning:: 
    If your sample and experiment do not satisfy all these assumptions, DeerLab will give incorrect results.


### PR DESCRIPTION
As of #183 DeerLab can handle orientation selection in the data. This PR updates the list of assumptions in the Theory section of the documentation.