### PR TITLE
Skip unit test if an error with the Tk backend of Matplotlib occurs

### DIFF
--- a/deerlab/utils/utils.py
+++ b/deerlab/utils/utils.py
@@ -1,10 +1,11 @@
+from copy import Error
 import warnings
 import numpy as np
 import cmath as math
 import scipy as scp
 import scipy.optimize as opt
 from types import FunctionType 
-
+from functools import wraps
 
 def parse_multidatasets(V_,K,weights,precondition=False):
 #===============================================================================
@@ -106,6 +107,7 @@ def parse_multidatasets(V_,K,weights,precondition=False):
         return V,Kmulti,weights,subset
 #===============================================================================
 
+#===============================================================================
 def der_snr(V):
     """
     DER_SNR Method
@@ -124,7 +126,9 @@ def der_snr(V):
     sigma  = 1.482602/np.sqrt(6)*np.median(abs(2.0*V[2:n-2] - V[0:n-4] - V[4:n]))
     
     return sigma
+#===============================================================================
 
+#===============================================================================
 def hccm(J,*args):
     """
     Heteroscedasticity Consistent Covariance Matrix (HCCM)
@@ -498,3 +502,31 @@ def multistarts(n,x0,lb,ub):
         x0 = [x0]
     return x0
 #===============================================================================
+
+# This is only required for the developers version which install pytest automatically
+try:
+    import pytest     
+    #===============================================================================
+    def skip_on(errclass, reason="Default reason"):
+        """ 
+        Skip a unit test in Pytest if a particular exception occurs during the execution of the test.
+        Source: modified from https://stackoverflow.com/a/63522579/16396391
+        """ 
+        # Func below is the real decorator and will receive the test function as param
+        def decorator_func(f):
+            @wraps(f)
+            def wrapper(*args, **kwargs):
+                try:
+                    # Try to run the test
+                    return f(*args, **kwargs)
+                except BaseException as error:
+                    if errclass in str(type(error)):
+                        # If exception of given type happens
+                        # just swallow it and raise pytest.Skip with given reason
+                        pytest.skip(reason)
+                    else: raise Error(error)
+            return wrapper
+
+        return decorator_func
+    #===============================================================================
+except: pass

--- a/test/test_fitmodel.py
+++ b/test/test_fitmodel.py
@@ -7,7 +7,7 @@ from deerlab.dd_models import dd_gauss
 from deerlab.bg_models import bg_exp, bg_hom3d
 from deerlab.ex_models import ex_4pdeer, ex_5pdeer, ex_7pdeer, ex_ovl4pdeer
 import deerlab as dl
-from deerlab.utils import ovl
+from deerlab.utils import ovl, skip_on
 
 
 def assert_experiment_model(model):
@@ -611,6 +611,7 @@ def test_V_scale_regularized():
     assert isinstance(fit.scale,float) and  abs(1 - scale/fit.scale) < 1e-2
 # ======================================================================
 
+@skip_on('_tkinter.TclError', reason="A problem with the Tk backend occured")
 def test_plot():
 # ======================================================================
     "Check that the plot method works"

--- a/test/test_fitmultimodel.py
+++ b/test/test_fitmultimodel.py
@@ -3,7 +3,7 @@ import numpy as np
 from deerlab import dipolarkernel, fitmultimodel, whitegaussnoise
 from deerlab.dd_models import dd_gengauss, dd_gauss, dd_rice, dd_gauss2, dd_rice3, dd_gauss3
 from deerlab.bg_models import bg_exp
-from deerlab.utils import ovl
+from deerlab.utils import ovl, skip_on
 
 def test_multigauss():
 #=======================================================================
@@ -319,6 +319,8 @@ def test_multigauss_split():
     assert ovl(P,fit.P) > 0.95 # more than 99% overlap
 #=======================================================================
 
+
+@skip_on('_tkinter.TclError', reason="A problem with the Tk backend occured")
 def test_plot():
 # ======================================================================
     "Check that the plot method works"

--- a/test/test_fitparamodel.py
+++ b/test/test_fitparamodel.py
@@ -2,7 +2,7 @@
 import numpy as np
 from deerlab import dipolarkernel, whitegaussnoise, fitparamodel
 from deerlab.dd_models import dd_gauss, dd_rice
-
+from deerlab.utils import skip_on
 
 def test_gaussian():
 # ======================================================================
@@ -225,6 +225,7 @@ def test_globalfit_scales():
     assert max(abs(np.asarray(scales)/np.asarray(fit.scale) - 1)) < 1e-2 
 #============================================================
 
+@skip_on('_tkinter.TclError', reason="A problem with the Tk backend occured")
 def test_plot():
 # ======================================================================
     "Check that the plot method works"

--- a/test/test_fitregmodel.py
+++ b/test/test_fitregmodel.py
@@ -2,7 +2,7 @@
 import numpy as np
 from deerlab import fitregmodel,dipolarkernel, regoperator, whitegaussnoise
 from deerlab.dd_models import dd_gauss,dd_gauss2
-from deerlab.utils import ovl
+from deerlab.utils import ovl, skip_on
 
 def assert_solver(regtype,solver):
 #============================================================
@@ -395,6 +395,7 @@ def test_globalfit_scales():
     assert max(abs(np.asarray(scales)/np.asarray(fit.scale) - 1)) < 1e-2 
 #============================================================
 
+@skip_on('_tkinter.TclError', reason="A problem with the Tk backend occured")
 def test_plot():
 #============================================================
     "Check the plotting method"

--- a/test/test_regoperator.py
+++ b/test/test_regoperator.py
@@ -59,7 +59,7 @@ def test_L1shape_noedges():
     assert L.shape==(n-1, n)
 #=======================================================================
 
-def test_L2shape():
+def test_L2shape_noedges():
 #=======================================================================
     "Check that L2 is returned with correct size if edges are excluded"
     

--- a/test/test_snlls.py
+++ b/test/test_snlls.py
@@ -1,7 +1,7 @@
 import numpy as np
 from deerlab import dipolarkernel,dd_gauss,dd_gauss2,snlls,whitegaussnoise
 from deerlab.bg_models import bg_exp
-from deerlab.utils import ovl
+from deerlab.utils import ovl, skip_on
 
 def assert_multigauss_SNLLS_problem(nonlinearconstr=True, linearconstr=True):
     # Prepare test data
@@ -382,6 +382,7 @@ def test_reg_huber():
     assert_reg_type(regtype='huber')
 #=======================================================================
 
+@skip_on('_tkinter.TclError', reason="A problem with the Tk backend occured")
 def test_plot():
 # ======================================================================
     "Check that the plot method works"


### PR DESCRIPTION
This PR introduces a new decorator `skip_on` which allows a test to be marked as skipped by `pytest` if a specific exception is raised. This is used to wrap the `test_plot()` unit tests throughout the test suite which randomly fail due to varied errors with the Tk backend of Matplotlib. 

This is the new behavior of `pytest` when this random error occurs:
![image](https://user-images.githubusercontent.com/48292540/127291596-671dc3ac-f21b-485b-8cc8-4175826bdfdd.png)
![image](https://user-images.githubusercontent.com/48292540/127291683-89ac49e7-8273-4964-8eab-2c2b9d5b8c65.png)

