### PR TITLE
`link`: Take model links as strings instead of `Parameter` objects

### DIFF
--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -787,7 +787,7 @@ def link(model,**links):
         The corresponding model parameter will be assigned to new parameter whose name is given 
         by the keyword name. For example:: 
 
-            newmodel = link(model,parC = [model.parA,model.parB])
+            newmodel = link(model,parC = ['parA','parB'])
 
         will return a new model where the values of ``parA`` and ``parB`` will be given by the
         new model parameter ``parC``. 
@@ -922,8 +922,9 @@ def link(model,**links):
     if not isinstance(model,Model):
         raise TypeError('The first argument must be a Model object.')
     newmodel = deepcopy(model)
-    for link_name in links: 
-        newmodel = _linkparameter(newmodel,links[link_name],link_name)
+    for link_newname in links: 
+        to_link = [getattr(newmodel,parname) for parname in links[link_newname]]
+        newmodel = _linkparameter(newmodel,to_link,link_newname)
     return newmodel
 #==============================================================================================
 

--- a/examples/advanced/ex_droplets_model.py
+++ b/examples/advanced/ex_droplets_model.py
@@ -47,10 +47,10 @@ def dropletmodel(t):
     # Create a dipolar signal model that is a linear combination of both components
     Vmodel = dl.combine(Vdis_model,Vld_model, addweights=True)
     Vmodel = dl.link(Vmodel,
-                    reftime1=[Vmodel.reftime1_1,Vmodel.reftime1_2],
-                    reftime2=[Vmodel.reftime2_1,Vmodel.reftime2_2],
-                    lam1=[Vmodel.lam1_1,Vmodel.lam1_2],
-                    lam2=[Vmodel.lam2_1,Vmodel.lam2_2])
+                    reftime1=['reftime1_1','reftime1_2'],
+                    reftime2=['reftime2_1','reftime2_2'],
+                    lam1=['lam1_1','lam1_2'],
+                    lam2=['lam2_1','lam2_2'])
     # Make the second weight dependent on the first one
     Vmodel = dl.relate(Vmodel,weight_2 = lambda weight_1: 1 - weight_1)
     return Vmodel,Vdis_model,Vld_model
@@ -64,17 +64,17 @@ Vmodel2,Vdismodel2,Vldmodel2 = dropletmodel(ts[1])
 globalModel = dl.expand(Vmodel1,Vmodel2)
 # Link global parameters toghether with new names
 globalModel = dl.link(globalModel,
-                eta = [globalModel.weight_1_1,globalModel.weight_1_2],
-                kdis = [globalModel.decay_1_1,globalModel.decay_1_2],
-                kld = [globalModel.decay_2_1,globalModel.decay_2_2],
-                Dld = [globalModel.stretch_2_1,globalModel.stretch_2_2],
-                rmean_dis = [globalModel.mean_1_1,globalModel.mean_1_2],
-                rmean_ld = [globalModel.mean_2_1,globalModel.mean_2_2],
-                width_dis = [globalModel.width_1_1,globalModel.width_1_2],
-                width_ld = [globalModel.width_2_1,globalModel.width_2_2],
-                lam1 = [globalModel.lam1_1,globalModel.lam1_2],
-                lam2 = [globalModel.lam2_1,globalModel.lam2_2],
-                reftime1 = [globalModel.reftime1_1,globalModel.reftime1_2])
+                eta = ['weight_1_1','weight_1_2'],
+                kdis = ['decay_1_1','decay_1_2'],
+                kld = ['decay_2_1','decay_2_2'],
+                Dld = ['stretch_2_1','stretch_2_2'],
+                rmean_dis = ['mean_1_1','mean_1_2'],
+                rmean_ld = ['mean_2_1','mean_2_2'],
+                width_dis = ['width_1_1','width_1_2'],
+                width_ld = ['width_2_1','width_2_2'],
+                lam1 = ['lam1_1','lam1_2'],
+                lam2 = ['lam2_1','lam2_2'],
+                reftime1 = ['reftime1_1','reftime1_2'])
 
 # Specify parameter boundaries and initial conditions 
 globalModel.eta.set(       lb=0.468, ub=0.57, par0=0.520)

--- a/examples/advanced/ex_global_twostates_parametric.py
+++ b/examples/advanced/ex_global_twostates_parametric.py
@@ -56,10 +56,10 @@ for n in range(Nsignals):
 globalmodel = dl.expand(*Vmodels)
 # Link the global parameters toghether
 globalmodel = dl.link(globalmodel,
-        meanA = [globalmodel.meanA_1, globalmodel.meanA_2, globalmodel.meanA_3],
-        meanB = [globalmodel.meanB_1, globalmodel.meanB_2, globalmodel.meanB_3],
-        widthA = [globalmodel.widthA_1, globalmodel.widthA_2, globalmodel.widthA_3],
-        widthB = [globalmodel.widthB_1, globalmodel.widthB_2, globalmodel.widthB_3])
+        meanA = ['meanA_1', 'meanA_2', 'meanA_3'],
+        meanB = ['meanB_1', 'meanB_2', 'meanB_3'],
+        widthA = ['widthA_1', 'widthA_2', 'widthA_3'],
+        widthB = ['widthB_1', 'widthB_2', 'widthB_3'])
 
 # Fit the datasets to the model globally
 fit = dl.fit(globalmodel,Vexps)

--- a/examples/advanced/ex_pseudotitration_parameter_free.py
+++ b/examples/advanced/ex_pseudotitration_parameter_free.py
@@ -56,8 +56,8 @@ Vmodels = [dl.dipolarmodel(t,r,Pmodel) for t in ts]
 titrmodel = dl.expand(*Vmodels)
 # Make the two components of the distance distriution global
 titrmodel = dl.link(titrmodel, 
-                PA = [titrmodel.P_1_1, titrmodel.P_1_2, titrmodel.P_1_3, titrmodel.P_1_4, titrmodel.P_1_5],
-                PB = [titrmodel.P_2_1, titrmodel.P_2_2, titrmodel.P_2_3, titrmodel.P_2_4, titrmodel.P_2_5])
+                PA = ['P_1_1', 'P_1_2', 'P_1_3', 'P_1_4', 'P_1_5'],
+                PB = ['P_2_1', 'P_2_2', 'P_2_3', 'P_2_4', 'P_2_5'])
 
 # FUnctionalize the chemical equilibrium model
 titrmodel.addnonlinear('Kdis',lb=3,ub=7,par0=5,description='Dissociation constant')

--- a/examples/basic/ex_global_different_deer.py
+++ b/examples/basic/ex_global_different_deer.py
@@ -33,7 +33,7 @@ V5pmodel.reftime2.set(lb=3,ub=3.5,par0=3.2)
 
 # Make the joint model with the distribution as a global parameters
 globalmodel = dl.expand(V4pmodel,V5pmodel)  
-globalmodel = dl.link(globalmodel, P = [globalmodel.P_1,globalmodel.P_2])
+globalmodel = dl.link(globalmodel, P = ['P_1','P_2'])
 
 # Fit the model to the data (with fixed regularization parameter)
 fit = dl.fit(globalmodel,[V4p,V5p],regparam=0.5)

--- a/examples/basic/ex_global_fitting_4pdeer.py
+++ b/examples/basic/ex_global_fitting_4pdeer.py
@@ -37,7 +37,7 @@ globalmodel = dl.expand(V1model,V2model,V3model)
 
 # Link the distance distribution into a global parameter 
 globalmodel = dl.link(globalmodel,
-        P=[globalmodel.P_1,globalmodel.P_2,globalmodel.P_3])
+        P=['P_1','P_2','P_3'])
 
 # Fit the model to the data
 fit = dl.fit(globalmodel,Vs)

--- a/test/test_model_link.py
+++ b/test/test_model_link.py
@@ -7,7 +7,7 @@ def test_link_name():
     "Check that the parameters are linked to the proper name"
     model = dl.dd_gauss2
 
-    linkedmodel = link(model,mean=[model.mean1,model.mean2])
+    linkedmodel = link(model,mean=['mean1','mean2'])
 
     assert hasattr(linkedmodel,'mean') and not hasattr(linkedmodel,'mean1') and not hasattr(linkedmodel,'mean2')
 # ======================================================================
@@ -17,7 +17,7 @@ def test_link_Nparam():
     "Check that the parameters are linked resulting in proper number of parameters"
     model = dl.dd_gauss2
 
-    linkedmodel = link(model,mean=[model.mean1,model.mean2])
+    linkedmodel = link(model,mean=['mean1','mean2'])
 
     assert linkedmodel.Nparam == model.Nparam - 1
 # ======================================================================
@@ -27,7 +27,7 @@ def test_link_Nparam_list():
     "Check that the combined model has the right number of parameters"
     model = dl.dd_gauss2
 
-    linkedmodel = link(model,mean=[model.mean1,model.mean2])
+    linkedmodel = link(model,mean=['mean1','mean2'])
 
     assert linkedmodel.Nparam == len(linkedmodel._parameter_list())
 # ======================================================================
@@ -38,8 +38,8 @@ def test_link_multiple():
     model = dl.dd_gauss3
 
     linkedmodel = link(model,
-            mean1=[model.mean1,model.mean2],
-            width2=[model.width2,model.width3])
+            mean1=['mean1','mean2'],
+            width2=['width2','width3'])
 
     assert linkedmodel.Nparam == model.Nparam - 2
 # ======================================================================
@@ -49,7 +49,7 @@ def test_link_call():
     "Check that linked parameter models return the correct responses"
     model = dl.dd_gauss2
 
-    linkedmodel = link(model,mean=[model.mean1,model.mean2])
+    linkedmodel = link(model,mean=['mean1','mean2'])
 
     x = np.linspace(0,10,400)
     ref = model(x,4,0.5,4,0.2,1,1)
@@ -65,8 +65,8 @@ def test_link_fit():
     model = dl.dd_gauss2
 
     linkedmodel = link(model,
-                mean=[model.mean1,model.mean2],
-                width=[model.width1,model.width2])
+                mean=['mean1','mean2'],
+                width=['width1','width2'])
     linkedmodel.mean.par0 = 3
     linkedmodel.width.par0 = 0.5
 
@@ -83,7 +83,7 @@ def test_link_linear_name():
     "Check that the parameters are linked to the proper name"
     model = dl.dd_gauss3
 
-    linkedmodel = link(model,amp=[model.amp1,model.amp3])
+    linkedmodel = link(model,amp=['amp1','amp3'])
 
     assert hasattr(linkedmodel,'amp') and not hasattr(linkedmodel,'amp1') and not hasattr(linkedmodel,'amp3')
 # ======================================================================
@@ -93,8 +93,8 @@ def test_link_linear_order():
     "Check that the parameters are linked to the proper name"
     model = dl.dd_gauss3
 
-    linkedmodel1 = link(model,amp=[model.amp1,model.amp3])
-    linkedmodel2 = link(model,amp=[model.amp3,model.amp1])
+    linkedmodel1 = link(model,amp=['amp1','amp3'])
+    linkedmodel2 = link(model,amp=['amp3','amp1'])
 
     for linkedmodel in [linkedmodel1,linkedmodel2]:
         assert hasattr(linkedmodel,'amp') and not hasattr(linkedmodel,'amp1') and not hasattr(linkedmodel,'amp3')
@@ -105,7 +105,7 @@ def test_link_linear_call():
     "Check that linked parameter models return the correct responses"
     model = dl.dd_gauss2
 
-    linkedmodel = link(model,amp=[model.amp1,model.amp2])
+    linkedmodel = link(model,amp=['amp1','amp2'])
 
     x = np.linspace(0,10,400)
     ref = model(x,4,0.5,2,0.2,0.9,0.9)
@@ -125,7 +125,7 @@ def test_vec_link_name():
     "Check that the parameters are linked to the proper name"
     model = double_vec
 
-    linkedmodel = link(model,vec=[model.vec1,model.vec2])
+    linkedmodel = link(model,vec=['vec1','vec2'])
 
     assert hasattr(linkedmodel,'vec') and not hasattr(linkedmodel,'vec1') and not hasattr(linkedmodel,'vec2')
 # ======================================================================
@@ -135,7 +135,7 @@ def test_vec_link_Nparam():
     "Check that the parameters are linked resulting in proper number of parameters"
     model = double_vec
 
-    linkedmodel = link(model,vec=[model.vec1,model.vec2])
+    linkedmodel = link(model,vec=['vec1','vec2'])
 
     assert linkedmodel.Nparam == model.Nparam - 40
 # ======================================================================
@@ -145,7 +145,7 @@ def test_vec_link_call():
     "Check that linked parameter models return the correct responses"
     model = double_vec
 
-    linkedmodel = link(model,vec=[model.vec1,model.vec2])
+    linkedmodel = link(model,vec=['vec1','vec2'])
 
     x = np.linspace(0,10,40)
     ref = model(1,2,dl.dd_gauss(x,3,0.2),dl.dd_gauss(x,3,0.2))
@@ -160,7 +160,7 @@ def test_vec_link_fit():
     "Check that linked parameter models can be properly fitted"
     model = double_vec
 
-    linkedmodel = link(model,vec=[model.vec1,model.vec2])
+    linkedmodel = link(model,vec=['vec1','vec2'])
     linkedmodel.shift.par0 = 1
     linkedmodel.scale.par0 = 2
     linkedmodel.shift.freeze(1)


### PR DESCRIPTION
Fixes issues with parameter indices when linking multiple parameters in the same model. Closes #221 

In the example
```python
import deerlab as dl
import numpy as np
from copy import deepcopy

r = np.linspace(2,6,300)
sigma = 0.1
modelA = deepcopy(dl.dd_gauss)
modelB = deepcopy(dl.dd_gauss)
model = dl.expand(modelA,modelB)
model = dl.link(model,
        mean=[model.mean_1,model.mean_2],
        width=[model.width_1,model.width_2],
        scale = [model.scale_1, model.scale_2])
``` 
First, the 'mean_*' parameters are linked. Since the parameters to be linked are passed as `Parameter` objects they have the indices of the original/unlinked model. Therefore, as soon as the `mean_*` parameters have been linked the indices of the intermediately linked model and the ones of the original one will no longer match, leading to the bug described in #221. 

A simple solution to this is to specify the link parameters as strings instead of `Parameter` objects. For the example above: 
```python
model = dl.link(model,
        mean=['mean_1','mean_2],
        width=['width_1','width_2'],
        scale = ['scale_1','scale_2'])
```

This has the additional advantage of being more compact than the previous interface.  
