### PR TITLE
Fix content of `model.signature` after `link()` or `relate()`

### DIFF
--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -930,9 +930,16 @@ def link(model,**links):
     if not isinstance(model,Model):
         raise TypeError('The first argument must be a Model object.')
     newmodel = deepcopy(model)
+    # Perform the linking, one by one
     for link_newname in links: 
         to_link = [getattr(newmodel,parname) for parname in links[link_newname]]
         newmodel = _linkparameter(newmodel,to_link,link_newname)
+    # Update the new model signature
+    for key in links.keys():
+        newmodel.signature = [key if arg==links[key][0] else arg for arg in newmodel.signature]
+        for arg in links[key]:
+            if arg in newmodel.signature: 
+                newmodel.signature.remove(arg)
     return newmodel
 #==============================================================================================
 
@@ -1275,6 +1282,11 @@ def relate(model,**functions):
     # Get the dependent's names and their function arguments
     dependents = [dependent for dependent in functions]
     arguments = [inspect.getfullargspec(functions[dependent]).args for dependent in dependents]
+
+    # Update the new model signature
+    for arg in [item for sublist in arguments for item in sublist]:
+        if arg in newmodel.signature: 
+            newmodel.signature.remove(arg)
 
     # Check and correct the order to of functionalization
     maxtrials = 2*len(dependents)

--- a/test/test_model_link.py
+++ b/test/test_model_link.py
@@ -33,6 +33,16 @@ def test_link_Nparam_list():
 # ======================================================================
 
 # ======================================================================
+def test_link_signature(): 
+    "Check the model signature after linking"
+    model = dl.dd_gauss2
+
+    linkedmodel = link(model,mean=['mean1','mean2'])
+
+    assert linkedmodel.signature==['r', 'mean', 'width1', 'width2', 'amp1', 'amp2']
+# ======================================================================
+
+# ======================================================================
 def test_link_multiple(): 
     "Check that multiple links can be established"
     model = dl.dd_gauss3

--- a/test/test_model_relate.py
+++ b/test/test_model_relate.py
@@ -22,6 +22,16 @@ def test_preserve_original():
 # ======================================================================
 
 # ======================================================================
+def test_relate_signature(): 
+    "Check the model signature after relate"
+    model = dl.dd_gauss2
+
+    newmodel = relate(model,mean1= lambda mean2: mean2)
+
+    assert newmodel.signature==['r', 'mean1', 'width1', 'width2', 'amp1', 'amp2']
+# ======================================================================
+
+# ======================================================================
 def test_Nparam_nonlin(): 
     "Check that the output model has the right number of parameters"
     model = dl.dd_gauss


### PR DESCRIPTION
Closes #233 