### PR TITLE
Improve performance of model evaluation/propagation for large datasets 

### DIFF
--- a/deerlab/utils/utils.py
+++ b/deerlab/utils/utils.py
@@ -495,7 +495,7 @@ def nearest_psd(A):
     # Symmetrize the matrix
     Asym = (A + A.T)/2
     # Construct positive semi-definite matrix via eigenvalue decomposition
-    eigval, eigvec = np.linalg.eig(Asym)
+    eigval, eigvec = np.linalg.eigh(Asym)
     eigval[eigval < 0] = 0
     Cpsd = np.real(eigvec.dot(np.diag(eigval)).dot(eigvec.T))
     # Avoid round-off errors


### PR DESCRIPTION
Closes #200 

As discussed in #200 the `nearest_psd` called by `_model_evaluation` as a post-optimization step, was causing a bottleneck for the analysis of large datasets. As the profiling revealed the bottleneck to be the eigenvalue decomposition using `eig` this PR focuses on mending that. 

This PR exploits the forced symmetrization of the input matrix in `nearest_psd`. Since the matrix is always symmetric, we can use the `numpy.linalg.eigh` function instead of the `numpy.linalg.eig` function.  The `numpy.linalg.eigh` is optimized for Hermitian or real symmetric matrices, providing a considerable boost in performance and solving the bottleneck.

### Using `numpy.linalg.eig`

Same analysis as shown in #200. The evaluation of `_model_evaluation` takes several seconds, exceeding the optimization itself. 

![Picture1](https://user-images.githubusercontent.com/48292540/140299266-043e8c3b-acfa-40df-8b35-042e55fe6389.png)


### Using `numpy.linalg.eigh`

The performance boost is clearly seen. The evaluation of `_model_evaluation` is reduced to about one second, which is acceptable given the dimensions of the dataset (`N=2000`).

![Picture1](https://user-images.githubusercontent.com/48292540/140299350-a982ffb1-d856-48be-b073-308e5a00c7c9.png)
 