### PR TITLE
Implement masking and other changes to the `fit` and `snlls` functions

### DIFF
--- a/deerlab/classes.py
+++ b/deerlab/classes.py
@@ -170,7 +170,7 @@ class UQResult:
             means = np.mean(samples,0)
             covmat = np.squeeze(samples).T@np.squeeze(samples)/np.shape(samples)[0] - means*means.T
             self.mean = means
-            self.median = self.percentile(50)
+            self.median = np.median(samples,0)
             self.std = np.squeeze(np.std(samples,0))
             self.covmat = covmat
 

--- a/deerlab/classes.py
+++ b/deerlab/classes.py
@@ -169,8 +169,9 @@ class UQResult:
         elif uqtype == 'bootstrap':
             means = np.mean(samples,0)
             covmat = np.squeeze(samples).T@np.squeeze(samples)/np.shape(samples)[0] - means*means.T
-            self.mean = means
-            self.median = np.median(samples,0)
+            self.mean = means 
+            self.median = self.percentile(50)
+            self.median = np.array([nth_samples[n,0] if np.all(nth_samples==nth_samples[0]) else self.median[n] for n,nth_samples in enumerate(samples.T)])
             self.std = np.squeeze(np.std(samples,0))
             self.covmat = covmat
 

--- a/deerlab/classes.py
+++ b/deerlab/classes.py
@@ -295,7 +295,7 @@ class UQResult:
             else:
                 profile = self.profile[n] 
             σ = self.__noiselvl
-            obj2likelihood = lambda f: 1/np.sqrt(σ*2*np.pi)*np.exp(-1/2*f/σ**2)
+            obj2likelihood = lambda f: 1/np.sqrt(σ*2*np.pi)*np.exp(-1/2*(f-np.min(f))/σ**2)
             profileinterp = interp1d(profile['x'], profile['y'], kind='slinear', fill_value=1e6,bounds_error=False)
             x = np.linspace(np.min(profile['x']), np.max(profile['x']), 2**10 + 1)
             pdf = obj2likelihood(profileinterp(x)) 

--- a/deerlab/dd_models.py
+++ b/deerlab/dd_models.py
@@ -966,8 +966,8 @@ def _wlc(r,L,Lp):
     
     P = np.zeros(len(r))
     
-    kappa = Lp/L
-    rnorm = r/L
+    kappa = Lp/np.maximum(L,1e-16)
+    rnorm = r/np.maximum(L,1e-16)
     crit  = kappa*(1 - rnorm)
 
     idx = crit>0.2

--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -1220,6 +1220,7 @@ def link(model,**links):
                 for info,constant in zip(model._constantsInfo,constants):
                     args.insert(info['argidx'],constant)                
             A = nonlinfcn(*args)
+            if len(A.shape)<2: A = np.expand_dims(A,1)
             Amapped = np.vstack([np.sum(np.atleast_2d(A[:,idx]),axis=1) for idx in linear_reduce_idx]).T
             return Amapped
         # ---------------------------------------------------------------------

--- a/deerlab/selregparam.py
+++ b/deerlab/selregparam.py
@@ -97,7 +97,7 @@ def selregparam(y, A, solver, method='aic', algorithm='brent', noiselvl=None,
 #=========================================================           
 
     # If multiple datasets are passed, concatenate the signals and kernels
-    y, A, weights,_, noiselvl = dl.utils.parse_multidatasets(y, A, weights, noiselvl)
+    y, A, weights,_,__, noiselvl = dl.utils.parse_multidatasets(y, A, weights, noiselvl)
 
     # The L-curve criteria require a grid-evaluation
     if method == 'lr' or method == 'lc':

--- a/deerlab/solvers.py
+++ b/deerlab/solvers.py
@@ -758,7 +758,7 @@ def snlls(y, Amodel, par0=None, lb=None, ub=None, lbl=None, ubl=None, nnlsSolver
     Amodel = _Amodel
 
     # Compute the fit residual
-    par_prev = nonlinfit
+    par_prev = nonlinfit.copy()
     _ResidualsFcn = lambda nonlinfit: ResidualsFcn(_unfrozen_subset(nonlinfit,nonlin_frozen,nonlin_parfrozen))
     res = _ResidualsFcn(nonlinfit)
 

--- a/docsrc/source/_static/theme_override.css
+++ b/docsrc/source/_static/theme_override.css
@@ -8786,14 +8786,14 @@
     color: var(--main-color);
    }
    a.headerlink {
-    color:rgba(var(--pst-color-headerlink),1);
+    color:#4550e6;
     font-size:.8em;
     padding:0 4px;
-    text-decoration:none
+    text-decoration:none    
    }
    a.headerlink:hover {
-    background-color:rgba(var(--pst-color-headerlink),1);
-    color:rgba(var(--pst-color-headerlink-hover),1)
+    background-color: #888fed;
+    color: #4550e6;
    }
    .heading-style,
    h1,

--- a/test/test_model_class.py
+++ b/test/test_model_class.py
@@ -409,7 +409,6 @@ def test_fit_fullyfrozen_linear():
     
     assert np.allclose(fitResult.model,mock_data)
 #================================================================
-test_fit_fullyfrozen_linear()
 
 def test_fit_fullyfrozen_nonlinear(): 
 #================================================================

--- a/test/test_model_merge.py
+++ b/test/test_model_merge.py
@@ -232,8 +232,9 @@ def test_fit_model():
     model2 = dl.dd_rice
     model = merge(model1,model2)
     x = np.linspace(0,10,400)
-    truth = [model1(x,3,0.2),model2(x,4,0.5)]
-    result = fit(model,truth,x,x)
+    truth = [model1(x,3,0.2),
+             model2(x,4,0.5)]
+    result = fit(model,truth,x,x,weights=[1,1])
 
     assert np.allclose(result.model[0],truth[0]) and np.allclose(result.model[1],truth[1])
 # ======================================================================

--- a/test/test_snlls.py
+++ b/test/test_snlls.py
@@ -684,3 +684,25 @@ def test_complex_model_uncertainty():
     assert (ciwidth.real < ciwidth.imag).all()
 # ======================================================================
  
+def test_masking():
+# ======================================================================
+    "Check that datapoints can be masked out"
+
+    x = np.linspace(0,7,100)
+    def model(p):
+        center, width = p
+        y = dd_gauss(x,center, width)
+        return y
+
+    mask = np.ones_like(x).astype(bool)   
+    mask[(x>2.5) & (x<3.5)] = False 
+
+    y = model([3, 0.5])  
+    yref = y.copy()
+    y[~mask] = 0 
+
+    fitmasked = snlls(y,model,par0=[4,0.2],lb=[1,0.05],ub=[6,5], mask=mask)
+    fit = snlls(y,model,par0=[4,0.2],lb=[1,0.05],ub=[6,5])
+
+    assert np.allclose(fitmasked.model,yref) and not np.allclose(fit.model,yref) 
+# ======================================================================


### PR DESCRIPTION
### Features and changes 

- Add option to pass boolean masks to the `fit` and `snlls` functions. Closes #248  
- Correct behavior of `fit` to allow passing all `snlls` optional keywords properly 
- Automatically add documentation of the `snlls` optional arguments to the `fit` documentation 
- Correct behavior of weights. No longer normalized after specification and kept as specified by the users. 
- Add verbose option to `snlls` wrapping the `least_squares` verbose system.
- Fix/adapt multiple tests  