### PR TITLE
Altered correctphase to a use a vectorized analytical solution

### DIFF
--- a/deerlab/correctphase.py
+++ b/deerlab/correctphase.py
@@ -46,46 +46,40 @@ def correctphase(V, phase='posrealint', full_output=False):
 
     V_2d = V.copy()
     if V_2d.ndim == 1:
-        Ntraces = 1
-        V_2d = V_2d[:,np.newaxis]
-    else:
-        Ntraces = V_2d.shape[1]
-    n = V_2d.shape[0]
- 
-    phaseopt = np.zeros(Ntraces)
-    for i in range(Ntraces):
-        V_ = V_2d[:,i]
+        V_2d = V_2d[:, np.newaxis]
 
-        # Get the average phase in the signal
-        phaseav = np.mean(np.angle(V_))
+    V_2d = V_2d.T
 
-        # Objective function for optimization of the phase
-        phase_objfcn = lambda phase: np.linalg.norm(np.imag(V_*np.exp(-1j*phase)))
+    # Calculate 3 points of cost function which should be a smooth, continuous sine wave with a frequency of 2 * phi
+    phis = np.array([0, np.pi / 2, np.pi]) / 2
+    costs = np.imag(V_2d[:, None] * np.exp(1j * phis)[None, :, None])
+    costs = (costs * costs).sum(axis=-1)
 
-        pars = opt.fmin(phase_objfcn,phaseav,maxfun=1e5,maxiter=1e5,disp=False)
-        
-        # Get the two phases that minimize the imaginary part
-        phases = [pars[0], pars[0]+np.pi]
-        realint = [np.sum(V_*np.exp(-1j*phase)) for phase in phases]
-            
-        if phase == 'posrealint':
-            phaseopt[i] =  phases[np.argmax(realint)]
-        elif phase == 'negrealint':
-            phaseopt[i] =  phases[np.argmin(realint)]
-        elif phase == 'close':
-            phaseopt[i] =  phases[np.argmin(abs(phases - phaseav))]
+    # Calculate sine function fitting 3 points
+    offset = (costs[:, 0] + costs[:, 2]) / 2
+    phase_shift = np.arctan2(costs[:, 0] - offset, costs[:, 1] - offset)
 
-        # Apply phase
-        V_2d[:,i] = V_*np.exp(-1j*phaseopt[i])
+    # Calculate extrema by the first derivative 0 and minima using the second derivative
+    possible_phis = np.array([(np.pi / 2 - phase_shift) / 2, (3 * np.pi / 2 - phase_shift) / 2]).T
+    second_deriv = -np.sin(2 * possible_phis + phase_shift[:, None])
+    phaseopt = possible_phis[second_deriv > 0]
 
-    if Ntraces==1:
-        V_2d = np.squeeze(V_2d)
+    tempspec = V_2d * np.exp(1j * phaseopt)[:, None]
+    if phase == 'posrealint':
+        phaseopt[tempspec.sum(axis=1) < 0] += np.pi
+    elif phase == 'negrealint':
+        phaseopt[tempspec.sum(axis=1) > 0] -= np.pi
+
+    V_2d = V_2d * np.exp(1j * phaseopt)[:, None]
+
+    V_2d = np.squeeze(V_2d.T)
 
     # Output
     Vreal = np.real(V_2d)
     Vimag = np.imag(V_2d)
+
     # Map phase angle to [-pi,pi) interval
-    phase = np.angle(np.exp(-1j*phaseopt)) 
+    phase = phaseopt
 
     if full_output:
         return Vreal,Vimag,phase


### PR DESCRIPTION
I recently noticed that `correctphase` can be a little slow when phasing 2D DEER data sets with a large number of scans. While this is generally insignificant when analyzing 1-2 DEER experiments it becomes a bit of a nuisance when analyzing 20+. 

This pull request proposes a vectorized analytical solution. The solution is based on the observation that the cost function (`imag(V) @ imag(V)`) is a periodic function of φ with a frequency of 2φ:

```python
V = np.arange(100, dtype=complex)
phis = np.linspace(0, 2*np.pi)

costs = V[None, :] * np.exp(1j * phis)[:, None]
costs = (costs.imag * costs.imag).sum(axis=-1)

A = max(costs) / 2
c = max(costs) / 2
b = 3 * np.pi / 2
sin2phi = A * np.sin(2 * phis + b) + c
```

![image](https://user-images.githubusercontent.com/18681246/148107080-6e81a145-c5da-44d9-93b4-83f8cc4e8ae2.png)

This can be exploited by solving for `b` in `A*sin(2*phi + b) + c` analytically using 3 points of the cost function and using the first and second derivatives to find the closest minima. 

This pull request implements the proposed solution resulting in a 30-150x speedup in my tests. These changes pass all existing DeerLab tests on my setup. 
