### PR TITLE
Fix parsing of Python 3.10 version in scheduled action workflow

### DIFF
--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
PR #255 added Python 3.10 to the evaluation matrix of the scheduled testing workflow for GHA. 

This PR fixes the parsing bug in the workflow since in the GHA parser `3.10` get parsed as a float `3.1`. Which led to an error since the 3.1 version is not available for the Ubunt VMs. Simply using quotes `"3.10"` fixes this. 