### PR TITLE
time2dist updates

### DIFF
--- a/deerlab/time2dist.py
+++ b/deerlab/time2dist.py
@@ -5,57 +5,69 @@
 import numpy as np
 from deerlab.utils import isempty
 
-def time2dist(t, M=[]):
+def time2dist(t, nr=None):
     r""" 
-    DeerAnalysis conversion from time-axis to distance-axis
-
-    .. warning:: This is a legacy function. Its use is not recommended for routine or accurate data analysis.
+    Empirical distance range given a DEER time axis
 
     Parameters
     ----------
     t : array_like
         Time axis, in microseconds.
-    M : int scalar
-        Length of output distance axis, by default equal length as time axis.
+    nr : scalar, integer
+        Length of output distance axis. If not given, only min and max distance are returned.
 
     Returns
     -------
-    r : ndarray
-        Distance axis, in nanometers.
+    r : ndarray or tuple
+        Distance axis, in nanometers, running between empirical lower and upper limits rmin and rmax.
+        Either an ndarray (if ``nr`` is given) or a tuple (if ``nr`` is not given).
 
     Notes
     -----
-    The minimal and maximal distances (rmin,rmax) are determined by the empirical
-    approximations derived by Gunnar Jeschke as implemented in DeerAnalysis.
+    The minimal and maximal distances, rmin and rmax, are empirical values that determine the
+    minimal and maximal distance for which the given time trace can provide reliable information.
 
-    These empirical equation approximate the minimal and maximal detectable distances
-    given a certain time step :math:`\Delta t` and trace length :math:`t_\text{max}`.
-
-    .. math:: 
-        
-        r_\text{min} = 4\left( \frac{4\Delta t \nu_0}{0.85} \right)^{1/3}
-
+    The minimum distance is determined by the time step :math:`\Delta t` and the Nyquist criterion:
 
     .. math:: 
         
-        r_\text{max} = 6\left( \frac{t_\text{max}}{2} \right)^{1/3}
+        r_\text{min} = \left( \frac{4\Delta t \nu_0}{0.85} \right)^{1/3}
 
-    where :math:`\nu_0` = 52.04 MHz is the dipolar frequency of between two nitroxide electron spins separated by 1 nm.
+    The maximum distance is determined by the requirement that at least half an oscillation
+    should be observable over the measured time window from :math:`t_\text{min}`
+    to :math:`t_\text{max}`.
+
+    .. math:: 
+        
+        r_\text{max} = 6\left( \frac{t_\text{max}-t_\text{min}}{2} \right)^{1/3}
+
+    where :math:`\nu_0` = 52.04 MHz nm^3.
+    
+    See Jeschke et al, Appl. Magn. Reson. 30, 473-498 (2006), https://doi.org/10.1007/BF03166213
 
     """
 
     t = np.atleast_1d(t)
 
-    if isempty(M):
-        M = len(t)
+    D = 52.04  # MHz nm^3
+    
+    # Minimum distance is determined by maximum frequency detectable with
+    # the given time increment, based on Nyquist
+    dt = np.mean(np.diff(t)) # time increment
+    nupara_max = 1/2/dt  # maximum parallel dipolar frequency (Nyquist)
+    nu_max = nupara_max/2  # maximum perpendicular dipolar frequency
+    nu_max = nu_max*0.85  # add a bit of buffer
+    rmin = (D/nu_max)**(1/3)
+    
+    # At least half a period of the oscillation
+    # should be observable in the time window.
+    trange = np.max(t) - np.min(t)
+    Tmax = trange*2  # maximum period length
+    rmax = (D*Tmax)**(1/3)
 
-    t = np.abs(t)
-    dt = np.mean(np.abs(np.diff(t)))
-    tmax = np.max(t)
-    ny0 = 52.04
-    rmin = (4*dt*ny0/0.85)**(1/3)
-    rmax = 6*(tmax/2)**(1/3)
-
-    r = np.linspace(rmin,rmax,M)
+    if nr is not None:
+        r = np.linspace(rmin, rmax, nr)
+    else:
+        r = (rmin, rmax)
 
     return r

--- a/test/test_time2dist.py
+++ b/test/test_time2dist.py
@@ -1,0 +1,40 @@
+import numpy as np
+from deerlab import time2dist
+
+def test_time2dist_outsize():
+    "Verify that the output has the correct size"
+
+    t = np.linspace(-1,5,300)
+    rminmax = time2dist(t)
+    assert len(rminmax)==2
+
+    nr = 200
+    r = time2dist(t,nr)
+    assert len(r)==nr
+
+
+def test_time2dist_rmin():
+    "Verify that the minimum distance is correct"
+
+    t, dt = np.linspace(-1, 5, 300, retstep=True)
+    rmin, _ = time2dist(t)
+
+    D = 52.04  # MHz nm^3
+    nu_max = 1/dt/2/2*0.85  # Nyquist freq, with buffer
+    rmin_ref = (D/nu_max)**(1/3)
+
+    assert np.max(np.abs(rmin - rmin_ref)) < 1e-10
+
+
+def test_time2dist_rmax():
+    "Verify that the maximum distance is correct"
+
+    t, dt = np.linspace(-1, 5, 300, retstep=True)
+    _, rmax = time2dist(t)
+
+    trange = max(t) - min(t)
+    D = 52.04  # MHz nm^3
+    Tmax = trange*2  # maximum period length
+    rmax_ref = (D*Tmax)**(1/3)
+
+    assert np.max(np.abs(rmax - rmax_ref)) < 1e-10


### PR DESCRIPTION
This PR improves `time2dist`:
- [x] Return (rmin,rmax) tuple if number of points is not given.
- [x] Cover case where tmin is smaller than zero.
- [x] Clarify origin of expressions with improved code, comments and docstring.
- [x] Add tests.
