### PR TITLE
require std dev input for `whitegaussnoise`

### DIFF
--- a/deerlab/whitegaussnoise.py
+++ b/deerlab/whitegaussnoise.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-def whitegaussnoise(t,level=1,rescale=False,seed=None):
+def whitegaussnoise(t, stdev=None, rescale=False, seed=None):
     r"""
     Generates a vector of white Gaussian (normal) noise
     
@@ -8,12 +8,12 @@ def whitegaussnoise(t,level=1,rescale=False,seed=None):
     ----------
     t : array_like
         Time axis.
-    level : float scalar
+    stdev : float scalar
         Noise level, i.e. standard deviation of underlying Gaussian distribution.
     rescale : boolean, optional
-        If true, rescales the noise vector such that its standard deviation is exactly equal
-        to ``level``. If false (default), the standard deviation of the noise vector can deviate
-        slightly from ``level``, particularly for short vectors.
+        If ``True``, rescales the noise vector such that its standard deviation is exactly equal
+        to ``stdev``. If ``False`` (default), the standard deviation of the noise vector can deviate
+        slightly from ``stdev``, particularly for short vectors.
     seed : integer scalar, optional
         If ``None`` (default), do not seed the random number generator. If an integer scalar is
         given (e.g. ``seed=137``), seed the random number generator with this number.
@@ -32,16 +32,20 @@ def whitegaussnoise(t,level=1,rescale=False,seed=None):
     with some integer number ``k`` before calling ``whitegaussnoise``.
     """
     
+    # Require standard deviation
+    if stdev is None:
+        raise SyntaxError('Noise standard deviation (second input) is missing.')
+    
     # Seed RNG if wanted
     if seed is not None:
         np.random.seed(seed)
     
     # Draw from standard normal distribution
     N = len(np.atleast_1d(t))
-    noise = np.random.normal(0,level,N)
+    noise = np.random.normal(0, stdev, N)
     
     # Rescale to sample std if wanted
     if rescale:
-        noise = level/np.std(noise)*noise
+        noise *= stdev/np.std(noise)
     
     return noise

--- a/deerlab/whitegaussnoise.py
+++ b/deerlab/whitegaussnoise.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-def whitegaussnoise(t, stdev=None, rescale=False, seed=None):
+def whitegaussnoise(t, std, rescale=False, seed=None):
     r"""
     Generates a vector of white Gaussian (normal) noise
     
@@ -8,12 +8,12 @@ def whitegaussnoise(t, stdev=None, rescale=False, seed=None):
     ----------
     t : array_like
         Time axis.
-    stdev : float scalar
+    std : float scalar
         Noise level, i.e. standard deviation of underlying Gaussian distribution.
     rescale : boolean, optional
         If ``True``, rescales the noise vector such that its standard deviation is exactly equal
-        to ``stdev``. If ``False`` (default), the standard deviation of the noise vector can deviate
-        slightly from ``stdev``, particularly for short vectors.
+        to ``std``. If ``False`` (default), the standard deviation of the noise vector can deviate
+        slightly from ``std``, particularly for short vectors.
     seed : integer scalar, optional
         If ``None`` (default), do not seed the random number generator. If an integer scalar is
         given (e.g. ``seed=137``), seed the random number generator with this number.
@@ -32,20 +32,16 @@ def whitegaussnoise(t, stdev=None, rescale=False, seed=None):
     with some integer number ``k`` before calling ``whitegaussnoise``.
     """
     
-    # Require standard deviation
-    if stdev is None:
-        raise SyntaxError('Noise standard deviation (second input) is missing.')
-    
     # Seed RNG if wanted
     if seed is not None:
         np.random.seed(seed)
     
-    # Draw from standard normal distribution
+    # Draw from normal distribution
     N = len(np.atleast_1d(t))
-    noise = np.random.normal(0, stdev, N)
+    noise = np.random.normal(0, std, N)
     
     # Rescale to sample std if wanted
     if rescale:
-        noise *= stdev/np.std(noise)
+        noise *= std/np.std(noise)
     
     return noise

--- a/test/test_model_class.py
+++ b/test/test_model_class.py
@@ -515,7 +515,7 @@ def test_bootCIs_parametric():
     "Check the bootstrapped confidence intervals of the fitted parameters"
     model = _getmodel('parametric')
 
-    noisydata = mock_data + whitegaussnoise(0.01,seed=1)
+    noisydata = mock_data + whitegaussnoise(x,0.01,seed=1)
     fitResult = fit(model,noisydata,bootstrap=3)
     
     assert_attributes_cis(fitResult,['mean1','mean2','width1','width2','amp1','amp2'])
@@ -526,7 +526,7 @@ def test_bootCIs_semiparametric():
     "Check the bootstrapped confidence intervals of the fitted parameters"
     model = _getmodel('semiparametric')
 
-    noisydata = mock_data + whitegaussnoise(0.01,seed=1)
+    noisydata = mock_data + whitegaussnoise(x,0.01,seed=1)
     fitResult = fit(model,noisydata,bootstrap=3)
     
     assert_attributes_cis(fitResult,['mean1','mean2','width1','width2','amp1','amp2'])
@@ -537,7 +537,7 @@ def test_bootCIs_nonparametric():
     "Check the bootstrapped confidence intervals of the fitted parameters"
     model = _getmodel('semiparametric')
 
-    noisydata = mock_data + whitegaussnoise(0.01,seed=1)
+    noisydata = mock_data + whitegaussnoise(x,0.01,seed=1)
     fitResult = fit(model,noisydata,bootstrap=3)
     
     assert_attributes_cis(fitResult,['amp1','amp2'])

--- a/test/test_whitegaussnoise.py
+++ b/test/test_whitegaussnoise.py
@@ -1,5 +1,6 @@
 from deerlab.utils.utils import assert_docstring
 import numpy as np
+import pytest
 from deerlab import whitegaussnoise
 from deerlab.utils import assert_docstring
 
@@ -56,8 +57,24 @@ def test_noseed():
     assert not np.array_equal(noise1,noise2)
 # ======================================================================
 
+
 def test_docstring():
 # ======================================================================
     "Check that the docstring includes all variables and keywords."
     assert_docstring(whitegaussnoise)
 # ======================================================================
+
+
+def test_requiredstdev():
+# ======================================================================
+    "Check that the standard deviation is a required argument"
+
+    N = 10
+    t = np.linspace(0,3,N)
+    
+    with pytest.raises(SyntaxError):
+        noise = whitegaussnoise(t)
+    
+# ======================================================================
+
+

--- a/test/test_whitegaussnoise.py
+++ b/test/test_whitegaussnoise.py
@@ -65,14 +65,14 @@ def test_docstring():
 # ======================================================================
 
 
-def test_requiredstdev():
+def test_requiredstd():
 # ======================================================================
     "Check that the standard deviation is a required argument"
 
     N = 10
     t = np.linspace(0,3,N)
     
-    with pytest.raises(SyntaxError):
+    with pytest.raises(TypeError):
         noise = whitegaussnoise(t)
     
 # ======================================================================


### PR DESCRIPTION
Small improvements to `whitegaussnoise`:
- [x] rename `level` to `stddev` to make it obvious how noise level should be provided
- [x] make `stddev` a required input, ie do not provide a default