### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,33 @@
+cff-version: 1.2.0
+message: "If you use this software in your work, please cite it as below."
+authors:
+- family-names: "Fábregas Ibáñez"
+  given-names: "Luis"
+  orcid: "https://orcid.org/0000-0002-8085-1256"
+- family-names: "Stoll"
+  given-names: "Stefan"
+  orcid: "https://orcid.org/0000-0003-4255-9550"
+- family-names: "Jeschke"
+  given-names: "Gunnar"
+  orcid: "https://orcid.org/0000-0001-6853-8585"
+title: "DeerLab"
+url: "https://github.com/JeschkeLab/DeerLab"
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Fábregas Ibáñez"
+    given-names: "Luis"
+    orcid: "https://orcid.org/0000-0002-8085-1256"
+  - family-names: "Stoll"
+    given-names: "Stefan"
+    orcid: "https://orcid.org/0000-0003-4255-9550"
+  - family-names: "Jeschke"
+    given-names: "Gunnar"
+    orcid: "https://orcid.org/0000-0001-6853-8585"
+  doi: "10.5194/mr-1-209-2020"
+  journal: "Magnetic Resonance"
+  start: 209 # First page number
+  end: 224 # Last page number
+  title: "DeerLab: a comprehensive software package for analyzing dipolar electron paramagnetic resonance spectroscopy data"
+  volume: 1
+  year: 2020

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2021 Luis Fabregas, Stefan Stoll, Gunnar Jeschke, and other contributors
+Copyright (c) 2019-2022 Luis Fabregas, Stefan Stoll, Gunnar Jeschke, and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/deerlab?color=brightgreen)
 
 ## About
-DeerLab is a Python package for the analysis of dipolar EPR (electron paramagnetic resonance) spectroscopy data. Dipolar EPR spectroscopy techniques include DEER (double electron-electron resonance), RIDME (relaxation-induced dipolar modulation enhancement), and others. The documentation can be found [here](https://jeschkelab.github.io/DeerLab/index.html).
 
-DeerLab consists of a collection of functions for modelling, data processing, and least-squares fitting. They can be combined in scripts to build custom data analysis workflows. DeerLab supports both classes of distance distribution models: non-parametric (Tikhonov regularization and related) and parametric (multi-Gaussians etc). It also provides a selection of background and experiment models.
+DeerLab is a comprehensive free scientific software package for Python focused on modelling, penalized least-squares regression, and uncertainty quantification. 
+It provides highly specialized on the analysis of dipolar EPR (electron paramagnetic resonance) spectroscopy data. Dipolar EPR spectroscopy techniques include DEER (double electron-electron resonance), RIDME (relaxation-induced dipolar modulation enhancement), and others. 
+
+The documentation can be found [here](https://jeschkelab.github.io/DeerLab/index.html).
 
 The early versions of DeerLab (up to version 0.9.2) are written in MATLAB. The old MATLAB codebase is archived and can be found [here](https://github.com/JeschkeLab/DeerLab-Matlab).
 
@@ -61,4 +63,4 @@ Here is the citation in bibtex format:
 
 DeerLab is licensed under the [MIT License](LICENSE).
 
-Copyright © 2019-2021: Luis Fábregas Ibáñez, Stefan Stoll, Gunnar Jeschke, and [other contributors](https://github.com/JeschkeLab/DeerLab/contributors).
+Copyright © 2019-2022: Luis Fábregas Ibáñez, Stefan Stoll, Gunnar Jeschke, and [other contributors](https://github.com/JeschkeLab/DeerLab/contributors).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The early versions of DeerLab (up to version 0.9.2) are written in MATLAB. The o
 
 ## Requirements
 
-DeerLab is available for Windows, Mac and Linux systems and requires **Python 3.6**, **3.7**, **3.8**, or **3.9**.
+DeerLab is available for Windows, Mac and Linux systems and requires **Python 3.6**, **3.7**, **3.8**, **3.9**, or  **3.10**.
 
 All additional dependencies are automatically downloaded and installed during the setup.
  

--- a/deerlab/bg_models.py
+++ b/deerlab/bg_models.py
@@ -1,7 +1,7 @@
 # bg_models.py - Background parametric models
 # ---------------------------------------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md). 
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
  
 import numpy as np
 import math as m

--- a/deerlab/bootstrap_analysis.py
+++ b/deerlab/bootstrap_analysis.py
@@ -1,7 +1,7 @@
 # bootstrap_analysis.py - Bootstrap analysis for uncertainty estimation
 # --------------------------------------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md).
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 import numpy as np
 import types

--- a/deerlab/classes.py
+++ b/deerlab/classes.py
@@ -1,5 +1,5 @@
 # This file is a part of DeerLab. License is MIT (see LICENSE.md).
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 import numpy as np
 from deerlab.utils import Jacobian, nearest_psd

--- a/deerlab/correctscale.py
+++ b/deerlab/correctscale.py
@@ -1,7 +1,7 @@
 # correctscale.py - Scale correction pre-processing  of dipolar signals
 # ---------------------------------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md). 
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 import numpy as np
 from deerlab import dipolarkernel, snlls

--- a/deerlab/correctzerotime.py
+++ b/deerlab/correctzerotime.py
@@ -2,7 +2,7 @@
 # correctzerotime.py - Zero-time correction of dipolar signals
 #--------------------------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md).
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 import numpy as np
 import scipy as scp

--- a/deerlab/dd_models.py
+++ b/deerlab/dd_models.py
@@ -1,7 +1,7 @@
 # dd_models.py - Distance distribtion parametric models
 # ---------------------------------------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md). 
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 
 import inspect

--- a/deerlab/dipolarbackground.py
+++ b/deerlab/dipolarbackground.py
@@ -1,7 +1,7 @@
 # dipolarbackground.py - Multipathway background generator
 # --------------------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md).
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 import numpy as np
 import inspect

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -1,7 +1,7 @@
 # dipolarkernel.py - Dipolar kernel operator
 # -----------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md).
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 # Numpy + SciPy
 import numpy as np

--- a/deerlab/dipolarmodel.py
+++ b/deerlab/dipolarmodel.py
@@ -1,7 +1,7 @@
 # dipolarmodel.py - DeerLab's dipolar EPR model generator
 # ---------------------------------------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md). 
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 import numpy as np
 from deerlab.dipolarkernel import dipolarkernel  

--- a/deerlab/distancerange.py
+++ b/deerlab/distancerange.py
@@ -1,7 +1,7 @@
 # distancerange.py - DeerAnalysis distance axis constructor
 # ------------------------------------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md). 
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 import numpy as np
 from deerlab.utils import isempty
 

--- a/deerlab/diststats.py
+++ b/deerlab/diststats.py
@@ -1,7 +1,7 @@
 # diststats.py - Distance distribution descriptors
 # -----------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md).
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 import numpy as np
 import warnings

--- a/deerlab/fftspec.py
+++ b/deerlab/fftspec.py
@@ -2,7 +2,7 @@
 # fftspec.py - Fast-Fourier transform spectrum
 # ---------------------------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md). 
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 import numpy as np
 from numpy.fft import fft, fftshift, fftfreq

--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -1,7 +1,7 @@
 # model.py - DeerLab's modelling interface
 # ---------------------------------------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md). 
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 import numpy as np
 from scipy.sparse import block_diag

--- a/deerlab/noiselevel.py
+++ b/deerlab/noiselevel.py
@@ -1,7 +1,7 @@
 # noiselevel.py - Noise level estimator
 # -----------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md).
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 from numpy import isreal, std, mean, shape, atleast_1d
 from deerlab.utils import movmean, der_snr

--- a/deerlab/profile_analysis.py
+++ b/deerlab/profile_analysis.py
@@ -1,7 +1,7 @@
 # profile_analysis.py - Likelihood/Objective function
 # --------------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md).
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 import numpy as np
 from scipy.stats import chi2 

--- a/deerlab/regoperator.py
+++ b/deerlab/regoperator.py
@@ -2,7 +2,7 @@
 # regoperator.py - Regularization Operators
 # --------------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md).
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 import numpy as np
 

--- a/deerlab/selregparam.py
+++ b/deerlab/selregparam.py
@@ -1,7 +1,7 @@
 # selregparam.py - Regularization parameter selection
 # -----------------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md).
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 import numpy as np 
 import scipy.optimize as opt

--- a/deerlab/solvers.py
+++ b/deerlab/solvers.py
@@ -1,7 +1,7 @@
 # solvers.py - Collection of least-squares solvers
 # --------------------------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md).
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 # External dependencies
 import numpy as np

--- a/deerlab/utils/gof.py
+++ b/deerlab/utils/gof.py
@@ -1,7 +1,7 @@
 # gof.py - Goodness-of-fit statistics
 # -----------------------------------
 # This file is a part of DeerLab. License is MIT (see LICENSE.md).
-# Copyright(c) 2019-2021: Luis Fabregas, Stefan Stoll and other contributors.
+# Copyright(c) 2019-2022: Luis Fabregas, Stefan Stoll and other contributors.
 
 import numpy as np
 import deerlab as dl

--- a/docsrc/source/conf.py
+++ b/docsrc/source/conf.py
@@ -18,7 +18,7 @@ sys.path.append(os.path.abspath('.'))
 
 # Project details
 project = 'DeerLab'
-copyright = '2019-2021, Luis Fábregas-Ibáñez, Stefan Stoll, and others'
+copyright = '2019-2022, Luis Fábregas-Ibáñez, Stefan Stoll, and others'
 author = 'Fabregas Ibanez'
 language = 'en'
 

--- a/docsrc/source/installation.rst
+++ b/docsrc/source/installation.rst
@@ -8,7 +8,7 @@ Requirements
 
 To install DeerLab, first install Python on your computer. Python can be downloaded from the `official Python distribution <https://www.python.org/>`_. There are
 many online tutorials to guide you through the installation and setup (see `here <https://realpython.com/installing-python/>`_ for example). Make sure you install
-one of the Python versions compatible with DeerLab, either **Python 3.6**, **3.7**, **3.8**, or **3.9**  
+one of the Python versions compatible with DeerLab, either **Python 3.6**, **3.7**, **3.8**, **3.9**, or  **3.10**.  
 
 .. rubric:: Windows systems
 

--- a/docsrc/source/others.rst
+++ b/docsrc/source/others.rst
@@ -55,7 +55,7 @@ DeerLab is a project that has been funded by the following sources:
 License
 -------
 
-Copyright (c) 2019-2021 Luis Fabregas, Stefan Stoll, and others
+Copyright (c) 2019-2022 Luis Fabregas, Stefan Stoll, and others
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Scientific/Engineering',
     ]
 )


### PR DESCRIPTION
Adds a citation format file to enable GitHub's button to request the citation metadata in the software's landing page. 

Info:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files#citing-something-other-than-software