### PR TITLE
Implement normalization conditions for model linear parameters

### DIFF
--- a/deerlab/classes.py
+++ b/deerlab/classes.py
@@ -182,7 +182,7 @@ class UQResult:
             # Calling the super class to avoid recursion
             if attr!='type' and super(UQResult, self).__getattribute__('type') == 'void':
                 # Check if the uncertainty quantification has been done, if not report that there is nothing in the object
-                raise ValueError('The requested attribute/method is not available. Uncertainty quantification has not been calculated during the fit by using the `uq=None` keyword.')
+                raise ValueError(f"The requested attribute/method ('{attr}') is not available. Uncertainty quantification has not been calculated during the fit by using the `uq=None` keyword.")
         except AttributeError:
             # Catch cases where 'type' attribute has still not been defined (e.g. when using copy.deepcopy)
             pass

--- a/deerlab/dd_models.py
+++ b/deerlab/dd_models.py
@@ -140,7 +140,7 @@ def freedist(r):
     dd_nonparametric = Model(_nonparametric,constants='r')
     dd_nonparametric.description = 'Non-parametric distribution model'
     # Parameters
-    dd_nonparametric.addlinear('P',vec=len(r),lb=0,par0=0,description='Non-parametric distance distribution',unit="nm⁻¹", normalization=lambda P: P/np.trapz(P))
+    dd_nonparametric.addlinear('P',vec=len(r),lb=0,par0=0,description='Non-parametric distance distribution',unit="nm⁻¹", normalization=lambda P: P/np.trapz(P,r))
     return dd_nonparametric
 
 

--- a/deerlab/dd_models.py
+++ b/deerlab/dd_models.py
@@ -140,7 +140,7 @@ def freedist(r):
     dd_nonparametric = Model(_nonparametric,constants='r')
     dd_nonparametric.description = 'Non-parametric distribution model'
     # Parameters
-    dd_nonparametric.addlinear('P',vec=len(r),lb=0,par0=0,description='Non-parametric distance distribution',unit="nm⁻¹")
+    dd_nonparametric.addlinear('P',vec=len(r),lb=0,par0=0,description='Non-parametric distance distribution',unit="nm⁻¹", normalization=lambda P: P/np.trapz(P))
     return dd_nonparametric
 
 

--- a/deerlab/dipolarmodel.py
+++ b/deerlab/dipolarmodel.py
@@ -157,7 +157,7 @@ def dipolarmodel(t, r, Pmodel=None, Bmodel=bg_hom3d, npathways=1, harmonics=None
             for param in model._parameter_list(order='vector'):
                 if np.any(getattr(model,param).linear):
                     parameters.append(getattr(model,param))
-                    linearparam.append({'name':param,'vec':len(np.atleast_1d(getattr(model,param).idx))})
+                    linearparam.append({'name':param,'vec':len(np.atleast_1d(getattr(model,param).idx)),'normalization':getattr(model,param).normalization})
                 elif not (model==Bmodel and param=='lam'):
                     signature.append(param)
                     parameters.append(getattr(model,param))
@@ -211,7 +211,7 @@ def dipolarmodel(t, r, Pmodel=None, Bmodel=bg_hom3d, npathways=1, harmonics=None
 
     # Add the linear parameters from the subset models            
     for lparam in linearparam:
-        DipolarSignal.addlinear(lparam['name'],vec=lparam['vec'])
+        DipolarSignal.addlinear(lparam['name'],vec=lparam['vec'],normalization=lparam['normalization'])
 
     if Pmodel is None:
         DipolarSignal.addlinear()

--- a/deerlab/dipolarmodel.py
+++ b/deerlab/dipolarmodel.py
@@ -25,7 +25,7 @@ def dipolarmodel(t, r, Pmodel=None, Bmodel=bg_hom3d, npathways=1, harmonics=None
         Vector of spin-spin distances, in nanometers.
     Pmodel : :ref:`Model`, optional
         Model for the distance distribution. If not specified, a non-parametric
-        distance distribution defined over r is used.
+        distance distribution defined over ``r`` is used.
     Bmodel : :ref:`Model`, optional
         Model for the intermolecular (background) contribution. If not specified,
         a background arising from a homogenous 3D distribution of spins is used.

--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -418,13 +418,13 @@ class Model():
 
 
     #---------------------------------------------------------------------------------------
-    def addlinear(self, key, vec=1, lb=-np.inf, ub=np.inf, par0=None, name=None, unit=None, description=None):
+    def addlinear(self, name, vec=1, normalization=None, lb=-np.inf, ub=np.inf, par0=None, unit=None, description=None):
         """
         Add a new linear parameter (:ref:`Parameter` object) to the model. 
 
         Parameters
         ----------
-        key : string
+        name : string
             Identifier of the parameter. This name will be used to refer
             to the parameter in the model.
 
@@ -446,19 +446,31 @@ class Model():
         unit : string, optional
             Physical unit of the parameter.
         """
-        self._error_if_already_exists(key)
+        # Check if the parameter already exists
+        self._error_if_already_exists(name)
+
+        # Check if the parameter is a vector
         if vec>1:
             idx = np.arange(self.Nparam,self.Nparam+vec) 
             self.Nparam += vec
             self.Nlin += vec
-            newparam = Parameter(name=key, linear=np.full(vec,True), parent=self, idx=idx, par0=np.full(vec,par0), lb=np.full(vec,lb), ub=np.full(vec,ub), value=np.full(vec,None),frozen=np.full(vec,False), unit=unit, description=description)
+            newparam = Parameter(name=name, linear=np.full(vec,True), parent=self, idx=idx, par0=np.full(vec,par0), lb=np.full(vec,lb), ub=np.full(vec,ub), value=np.full(vec,None),frozen=np.full(vec,False), unit=unit, description=description)
         else:
             idx = self.Nparam
             self.Nparam += 1
             self.Nlin += 1
-            newparam = Parameter(name=key, linear=True, parent=self, idx=idx, par0=par0, lb=lb, ub=ub, unit=unit, description=description)
-        setattr(self,key,newparam)
-        self.signature.append(key)
+            newparam = Parameter(name=name, linear=True, parent=self, idx=idx, par0=par0, lb=lb, ub=ub, unit=unit, description=description)
+
+        # Check if the normalization function is valid
+        newparam.normalization = normalization 
+        if newparam.normalization is not None:
+            if not callable(normalization):
+                raise TypeError('The normalization function must be a callable function.')
+                newparam.description = str(newparam.description) + ' (normalized)' 
+
+        # Add linear parameter to the model
+        setattr(self,name,newparam)
+        self.signature.append(name)
     #---------------------------------------------------------------------------------------
 
 
@@ -800,9 +812,12 @@ def _print_fitresults(fitresult,model):
             else:
                 # If parameter is scalar, report values and CIs
                 value = getattr(fitresult,param)
-                ci_lower,ci_upper = getattr(fitresult,param+'Uncert').ci(95)
-                value,ci_lower,ci_upper = [f'{var:.3f}' if var<1e4 else f'{var:.3g}' for var in [value,ci_lower,ci_upper]]
-                ci = f'({ci_lower},{ci_upper})'
+                if getattr(fitresult,param+'Uncert').type == 'void':
+                    ci = ''
+                else:
+                    ci_lower,ci_upper = getattr(fitresult,param+'Uncert').ci(95)
+                    value,ci_lower,ci_upper = [f'{var:.3f}' if var<1e4 else f'{var:.3g}' for var in [value,ci_lower,ci_upper]]
+                    ci = f'({ci_lower},{ci_upper})'
         else:
             # If parameter is vectorial, print just dots
             value = '...'
@@ -910,6 +925,15 @@ def fit(model_, y, *constants, par0=None, penalties=None, bootstrap=0, noiselvl=
     if model.Nlin==0:
         model.addlinear('scale',lb=-np.inf,ub=np.inf,description='Scaling factor')
 
+    normalization = False
+    for key in model._parameter_list():
+        param = getattr(model,key)
+        if np.all(param.linear):
+            if param.normalization is not None:
+                model.addnonlinear(f'{key}_scale',lb=-np.inf,ub=np.inf,par0=1,description=f'Normalization factor of {key}')
+                getattr(model,f'{key}_scale').freeze(1)
+                normalization = True
+
     # Get boundaries and conditions for the linear and nonlinear parameters
     ubl,ub = model._split_linear(model._vecsort(model._getvector('ub')))
     lbl,lb = model._split_linear(model._vecsort(model._getvector('lb')))
@@ -1003,14 +1027,13 @@ def fit(model_, y, *constants, par0=None, penalties=None, bootstrap=0, noiselvl=
             fitresults.modelUncert = fitresults.modelUncert[0]
     # Get some basic information on the parameter vector
     keys = model._parameter_list(order='vector')
- 
+
     # Dictionary of parameter names and fitted values
     FitResult_param = {key : fitvalue if len(fitvalue)>1 else fitvalue[0] for key,fitvalue in zip(keys,[fitresults.param[idx] for idx in param_idx])}
     # Dictionary of parameter names and fit uncertainties
     FitResult_paramuq = {f'{key}Uncert': model._getparamuq(fitresults.paramUncert,idx) for key,idx in zip(keys,param_idx)}
     # Dictionary of other fit quantities of interest
     FitResult_dict = {key: getattr(fitresults,key) for key in ['param','paramUncert','model','modelUncert','cost','plot','residuals','stats','regparam']}
-
 
     _paramlist = model._parameter_list('vector')
     def propagate(model,*constants,lb=None,ub=None):
@@ -1094,11 +1117,24 @@ def fit(model_, y, *constants, par0=None, penalties=None, bootstrap=0, noiselvl=
         return response
     # ----------------------------------------------------------------------------
 
+    # Enforce normalization of the linear parameters (if needed) for the final output
+    FitResult_param_,FitResult_paramuq_ = FitResult_param.copy(),FitResult_paramuq.copy()
+    if normalization:
+        for key in keys:
+            param = getattr(model,key)
+            param.unfreeze()
+            if np.all(param.linear):
+                if param.normalization is not None:
+                    non_normalized = FitResult_param_[key] # Non-normalized value
+                    FitResult_param_[key] = param.normalization(FitResult_param_[key]) # Normalized value
+                    FitResult_param_[f'{key}_scale'] = np.mean(non_normalized/FitResult_param_[key]) # Normalization factor
+                    FitResult_paramuq_[f'{key}Uncert'] = FitResult_paramuq_[f'{key}Uncert'].propagate(lambda x: x/FitResult_param[f'{key}_scale'], lb=param.lb, ub=param.ub) # Normalization of the uncertainty
+                    FitResult_paramuq_[f'{key}_scaleUncert'] = UQResult('void')
     if len(noiselvl)==1: 
         noiselvl = noiselvl[0]
 
     # Generate FitResult object from all the dictionaries
-    fitresult = FitResult({**FitResult_param,**FitResult_paramuq, **FitResult_dict,'penweights':penweights,'noiselvl':noiselvl, 'propagate': propagate, 'evaluate': evaluate}) 
+    fitresult = FitResult({**FitResult_param_,**FitResult_paramuq_, **FitResult_dict,'penweights':penweights,'noiselvl':noiselvl, 'propagate': propagate, 'evaluate': evaluate}) 
     fitresult._summary = _print_fitresults(fitresult,model)
 
     return fitresult
@@ -1448,10 +1484,12 @@ def _combinemodels(mode,*inputmodels,addweights=False):
     # Add the linear parameters from the subset models   
     lin_param_set = []
     for param in _unique_ordered(lin_params):
-        lin_param_set.append({'name':param, 'vec':np.sum(lin_params==param)})
+        parname,idx = param.split('_')
+        normalization = getattr(models[int(idx)-1],parname).normalization
+        lin_param_set.append({'name':param, 'vec':np.sum(lin_params==param), 'normalization':normalization})
 
     for lparam in lin_param_set:
-        combinedModel.addlinear(lparam['name'], vec=lparam['vec'])
+        combinedModel.addlinear(lparam['name'], vec=lparam['vec'], normalization=lparam['normalization'])
 
     parameters = np.concatenate([arguments,lin_params])
     # Import all parameter information from the subset models

--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -1570,13 +1570,13 @@ def relate(model,**functions):
         if dependent_name not in model_parameters:
             raise KeyError(f"The assigned parameter '{dependent_name}' is not a parameter of the input model.")
 
-        if getattr(model,dependent_name).linear:
+        if np.all(getattr(model,dependent_name).linear):
             raise TypeError(f"Linear parameters cannot be used.")
 
         for arg in arguments_names:
             if arg not in model_parameters:
                 raise KeyError(f"The function argument '{arg}' is not a parameter of the input model.")
-            if getattr(model,arg).linear:
+            if np.all(getattr(model,arg).linear):
                 raise TypeError(f"Linear parameters cannot be used.")
 
         param_idx = 0

--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -432,6 +432,11 @@ class Model():
             Number of elements in the parameter. If ``vec>1`` then the parameter will represent a 
             vector of linear parameters of length ``vec``. By default, a scalar parameter is defined.
 
+        normalization : callable, optional
+            Normalization function of the parameter. If specified, upon fitting the parameter will be normalized and 
+            an the normalization factor will be reported separately. Does not add an additional normalization factor parameter. 
+            Must be function taking the parameter and returning the normalized parameter.
+            
         lb : float or array_like, optional
             Lower bound of the parameter. For vectorized parameters, must be a 
             vector with ``vec`` elements. If not specified, it is set to ``-np.inf``.
@@ -439,6 +444,7 @@ class Model():
         ub : float or array_like, optional
             Lower bound of the parameter. For vectorized parameters, must be a
             vector with ``vec`` elements.  If not specified, it is set to ``+np.inf``.
+
 
         description : string, optional 
             Descriptrion of the parameter. 

--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -1128,7 +1128,7 @@ def fit(model_, y, *constants, par0=None, penalties=None, bootstrap=0, noiselvl=
                     non_normalized = FitResult_param_[key] # Non-normalized value
                     FitResult_param_[key] = param.normalization(FitResult_param_[key]) # Normalized value
                     FitResult_param_[f'{key}_scale'] = np.mean(non_normalized/FitResult_param_[key]) # Normalization factor
-                    FitResult_paramuq_[f'{key}Uncert'] = FitResult_paramuq_[f'{key}Uncert'].propagate(lambda x: x/FitResult_param[f'{key}_scale'], lb=param.lb, ub=param.ub) # Normalization of the uncertainty
+                    FitResult_paramuq_[f'{key}Uncert'] = FitResult_paramuq_[f'{key}Uncert'].propagate(lambda x: x/FitResult_param_[f'{key}_scale'], lb=param.lb, ub=param.ub) # Normalization of the uncertainty
                     FitResult_paramuq_[f'{key}_scaleUncert'] = UQResult('void')
     if len(noiselvl)==1: 
         noiselvl = noiselvl[0]

--- a/docsrc/source/dipolar_guide_fitting.rst
+++ b/docsrc/source/dipolar_guide_fitting.rst
@@ -74,7 +74,10 @@ For a quick summary of the fit results, including goodness-of-fit statistics and
      reftime     0.096     (0.092,0.100)              μs     Refocusing time                       
      conc        295.909   (279.412,312.405)          μM     Spin concentration                    
      P           ...       (...,...)                 None    Non-parametric distance distribution  
+     P_scale     1.001e5                             None    Normalization factor of P 
     =========== ========= ========================= ======= ====================================== 
+
+The values of vectorized parameters such as ``P`` are not shown in this summary and shown instead as ``...``. The additional value ``P_scale`` corresponds to the overall scaling factor of the distance distribution (and hence of the dipolar signal) since the fitted distance distribution is normalized such that ``trapz(P,r)==1``.    
 
 Any specific quantities can be extracted from the ``results`` object. For each parameter in the model, the ``results`` output contains an attribute ``results.<parameter>`` named after the parameter containing the fitted value of that parameter, as well as another attribute ``results.<parameter>Uncert`` containing the uncertainty estimates of that parameter, from which confidence intervals can be constructed (the :ref:`uncertainty guide <uncertainty>` for details). For example: :: 
 

--- a/docsrc/source/modelling_guide.rst
+++ b/docsrc/source/modelling_guide.rst
@@ -175,7 +175,6 @@ Models with linear parameters
 Linear parameters do not take part in the non-linear function of the model and hence must be declared after the non-linear part of the model has been constructed (as described in the previous section). Using the ``addlinear`` method of the ``Model`` class, we can introduce any number of linear parameters to the model. The ``addlinear`` method takes the name of the parameter as its first argument. Other attributes of the linear parameter (such as boundaries) can be specified as additional keyword arguments. 
 It is important to note that the order in which the parameters are introduced must match the shape of the matrix returned by ``nonlinear_fcn``.
 
-
 Additionally, DeerLab introduces another distinction between linear parameters. In addition, linear parameters can be defined in scalar or vector form. 
 
 
@@ -325,6 +324,24 @@ By printing the model, we can check that the model has only two parameters: ::
      dist        0     inf   linear     No     None    None         
     ======= ======= ======= ======== ======== ======= ============= 
 
+
+
+Imposing normalization on the linear parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sometimes, the linear parameters represent quantities that have certain normalization constraints. For example, a linear parameter representing a probability density function would require its trapezoidal integration to equal one. Such normalization criteria can be specified via the ``normalization`` optional argument of the ``addlinear`` method.   ::
+
+    # Definition of the non-linear function of the model
+    def nonlinear_fcn(nonlinparam1,nonlinparam2,*nonlinparamN):
+        y = ...
+        return y
+    # Construction of the model
+    mymodel = dl.Model(nonlinear_fcn)
+
+    # Add vector-form linear parameter (vector with N-elements) with a normalization condition
+    mymodel.addlinear('linparam1', vec=N, normalization= lambda linparam1: fcn(linparam1))
+
+Specifying normalization criteria does not affect the model evaluation or fitting. However, when the model is fitted and the fitted parameters are reported, the program will report the normalized value of ``linparam1`` as well as an additional value ``linparam1_scale`` which reports the normalization factor/scale of the linear parameter. 
 
 .. _modelling_constants:
 

--- a/test/test_dipolarmodel.py
+++ b/test/test_dipolarmodel.py
@@ -248,7 +248,18 @@ def test_fit_Pnonparametric():
     
     result = fit(Vmodel,V1path,nonlin_tol=1e-5)
 
-    assert ovl(result.P/1e5,Pr)>0.975
+    assert ovl(result.P,Pr)>0.975
+# ======================================================================
+
+# ======================================================================
+def test_fit_Pnonparametric_normalization(): 
+    "Check that the model with one dipolar pathway is correct"
+
+    Vmodel = dipolarmodel(t,r,Bmodel=bg_hom3d,npathways=1)
+    
+    result = fit(Vmodel,V1path,nonlin_tol=1e-5)
+
+    assert np.isclose(np.trapz(result.P,r),1)
 # ======================================================================
 
 tdeer = np.linspace(-0.5,5,300)

--- a/test/test_model_class.py
+++ b/test/test_model_class.py
@@ -114,6 +114,16 @@ def test_addlinear_set():
     assert getattr(model.amp1,'lb')==0 and getattr(model.amp1,'ub')==10 
 #================================================================
 
+def test_addlinear_normalization():
+#================================================================
+    "Check that linear parameters can be properly added with a normalization function"
+    model = Model(gauss2_design)
+    model.addlinear('amp1',lb=0, normalization=lambda x: 2*x)
+    model.addlinear('amp2',lb=0, normalization=lambda x: 3*x)
+
+    assert 'amp1' in model.__dict__ and 'amp2' in model.__dict__
+#================================================================
+
 def test_addlinear_call_keywords():
 #================================================================
     "Check that calling the model with parameters returns the correct response"
@@ -630,6 +640,9 @@ def _getmodel_axis(type,vec=50):
     elif type=='nonparametric_vec':
         model = Model(lambda x: np.eye(len(x)),constants='x')
         model.addlinear('dist',lb=0,vec=vec)
+    elif type=='nonparametric_vec_normalized':
+        model = Model(lambda x: np.eye(len(x)),constants='x')
+        model.addlinear('dist',lb=0,vec=vec,normalization=lambda dist:dist/np.sum(dist))
     return model
 #----------------------------------------------------------------
 
@@ -670,6 +683,17 @@ def test_fit_nonparametric_vec_constant():
 #================================================================
     "Check that a vectorized nonparametric model can be correctly fitted while specifying an axis"
     model = _getmodel_axis('nonparametric_vec',vec=80)
+
+    x = np.linspace(0,10,80)
+    fitResult = fit(model,mock_data_fcn(x),x,noiselvl=1e-10)
+    
+    assert np.allclose(fitResult.model,mock_data_fcn(x),atol=1e-3)
+#================================================================
+
+def test_fit_nonparametric_vec_normalized_constant(): 
+#================================================================
+    "Check that a vectorized nonparametric model can be correctly fitted while specifying an axis"
+    model = _getmodel_axis('nonparametric_vec_normalized',vec=80)
 
     x = np.linspace(0,10,80)
     fitResult = fit(model,mock_data_fcn(x),x,noiselvl=1e-10)
@@ -827,6 +851,19 @@ def test_fit_evaluate_nonparametric_vec():
     assert np.allclose(response,mock_data_fcn(x))
 #================================================================
 
+def test_fit_evaluate_nonparametric_vec_normalized(): 
+#================================================================
+    "Check the evaluate method of the fitResult object for evaluation of a vectorized nonparametric model"
+    model = _getmodel_axis('nonparametric_vec_normalized',vec=80)
+
+    x = np.linspace(0,10,80)
+    fitResult = fit(model,mock_data_fcn(x),x)
+    
+    response = fitResult.evaluate(model,x)
+
+    assert np.allclose(response,mock_data_fcn(x))
+#================================================================
+
 def test_fit_evaluate_semiparametric(): 
 #================================================================
     "Check the evaluate method of the fitResult object for evaluation of a semiparametric model"
@@ -916,6 +953,19 @@ def test_fit_propagate_nonparametric_vec():
     assert_cis(modeluq)
 #================================================================
 
+def test_fit_propagate_nonparametric_vec_normalized(): 
+#================================================================
+    "Check the propagate method of the fitResult object for evaluation of a vectorized nonparametric model"
+    model = _getmodel_axis('nonparametric_vec_normalized',vec=80)
+
+    x = np.linspace(0,10,80)
+    fitResult = fit(model,mock_data_fcn(x),x)
+    
+    modeluq = fitResult.propagate(model, x, lb=np.zeros_like(x))
+
+    assert_cis(modeluq)
+#================================================================
+
 def test_fit_propagate_semiparametric(): 
 #================================================================
     "Check the propagate method of the fitResult object for evaluation of a semiparametric model"
@@ -986,6 +1036,19 @@ def test_fit_propagate_nonparametric_vec_bootstrapped():
 #================================================================
     "Check the propagate method of the fitResult object for evaluation of a vectorized nonparametric model"
     model = _getmodel_axis('nonparametric_vec',vec=80)
+
+    x = np.linspace(0,10,80)
+    fitResult = fit(model,mock_data_fcn(x),x,bootstrap=3)
+    
+    modeluq = fitResult.propagate(model, x, lb=np.zeros_like(x))
+
+    assert_cis(modeluq)
+#================================================================
+
+def test_fit_propagate_nonparametric_vec_normalized_bootstrapped(): 
+#================================================================
+    "Check the propagate method of the fitResult object for evaluation of a vectorized nonparametric model"
+    model = _getmodel_axis('nonparametric_vec_normalized',vec=80)
 
     x = np.linspace(0,10,80)
     fitResult = fit(model,mock_data_fcn(x),x,bootstrap=3)


### PR DESCRIPTION
Implements a way to define normalization conditions on the linear parameters of a model. Closes #284 

- [x] Implement the core functionality
- [x] Add tests, particularly against the model manipulation functions 
- [x] Add docstrings and documentation

Following the example in #284: 
```python
model.addlinear('P',vec=len(r), normalization= lambda P: P/np.trapz(P,r))
results = dl.fit(model,Vexp)
```
The model remains unchanged as the normalization does not affect the linear parameter nature, e.g. `print(model)` gives
```
Description: Dipolar signal model
Signature: (mod, reftime, conc, P)
Constants: []
Parameter Table: 
========= ======= ======= ======== ======== ====== ====================================== 
 Name      Lower   Upper    Type    Frozen   Unit   Description                           
========= ======= ======= ======== ======== ====== ====================================== 
 mod           0       1   nonlin     No            Modulation depth                      
 reftime    -inf     inf   nonlin     No      μs    Refocusing time                       
 conc       0.01   5e+03   nonlin     No      μM    Spin concentration                    
 P             0     inf   linear     No     nm⁻¹   Non-parametric distance distribution  
========= ======= ======= ======== ======== ====== ====================================== 
```


Now printing the results via ``print(results)`` gives
```
Goodness-of-fit: 
========= ============= ============ ======= ========= 
 Dataset   Noise level   Reduced 𝛘2   RMSD      AIC    
========= ============= ============ ======= ========= 
   #1         1.580        1.097      1.644   290.449  
========= ============= ============ ======= ========= 
Model parameters: 
=========== ==================== ========================= ====== ====================================== 
 Parameter   Value                95%-Confidence interval   Unit   Description                           
=========== ==================== ========================= ====== ====================================== 
 mod         0.314                (0.255,0.373)                    Modulation depth                      
 reftime     0.001                (-0.008,0.010)             μs    Refocusing time                       
 conc        50.277               (31.925,68.630)            μM    Spin concentration                    
 P           ...                  (...,...)                 nm⁻¹   Non-parametric distance distribution  
 P_scale     1392.5009885329157                             None   Normalization factor of P             
=========== ==================== ========================= ====== ====================================== 
```
Where now `results.P` is correctly normalized 
```
>>> np.trapz(results.P,r)
1
```
and the overall scale is contained in ``P_scale``
