### PR TITLE
Implement dropdown navigation bar for the documentation

### DIFF
--- a/docsrc/source/_static/theme_override.css
+++ b/docsrc/source/_static/theme_override.css
@@ -9949,3 +9949,71 @@ text-decoration: none;
     vertical-align: baseline;
     border-radius: .25rem;
     transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+}
+
+
+
+
+/* The container <div> - needed to position the dropdown content */
+.dropdown {
+position: relative;
+display: inline-block;
+}
+
+/* The container <div> - needed to position the dropdown content */
+.dropbtn {
+    padding: 0 .5rem;
+    color: rgba(var(--pst-color-navbar-link),1);
+    }
+
+/* Dropdown Content (Hidden by Default) */
+.dropdown-content {
+display: none;
+position: absolute;
+background-color: #fff;
+box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+z-index: 1;
+}
+
+/* Links inside the dropdown */
+.dropdown-content a {
+color: black;
+padding: 8px 12px;
+text-decoration: none;
+display: block;
+font-size: 15px;
+}
+
+.dropbtn::after {
+    display: inline-block;
+    margin-left: .255em;
+    vertical-align: .255em;
+    content: "";
+    border-top: .3em solid;
+    border-right: .3em solid transparent;
+    border-bottom: 0;
+    border-left: .3em solid transparent;
+}
+
+/* Change color of dropdown links on hover */
+.dropdown-content a:hover {
+    background-color: var(--main-color-light);
+    color: var(--main-color);
+    font-size: 15px;
+}
+
+/* Show the dropdown menu on hover */
+.dropdown:hover .dropdown-content {
+    display: block;
+}
+
+/* Change the background color of the dropdown button when the dropdown content is shown */
+.dropdown:hover .dropbtn {
+    background-color: var(--main-color-light);
+    color: var(--main-color);
+    border-radius: 10px;
+    text-decoration: none;
+} 
+
+
+

--- a/docsrc/source/_templates/nav.html
+++ b/docsrc/source/_templates/nav.html
@@ -1,0 +1,82 @@
+{%- set userguide_dropdown_navigation = [
+    ('Basics', pathto('basics')),
+    ('Getting Started', pathto('getting_started')),
+    ('Modelling', pathto('dipolar_guide_modelling')),
+    ('Fitting', pathto('dipolar_guide_fitting')),
+    ('Theory', pathto('theory')),]
+  -%}
+  
+
+{%- set advancedguide_dropdown_navigation = [
+('Modelling Guide', pathto('modelling_guide')),
+('Fitting Guide', pathto('fitting_guide')),
+('Uncertainty Guide', pathto('uncertainty_guide')),]
+-%}
+
+{%- set more_dropdown_navigation = [
+  ('Release Notes', pathto('changelog')),
+  ('Contributing', pathto('contributing')),
+  ('Support', pathto('funding')),
+  ('License', pathto('license')),
+  ('GitHub', 'https://github.com/JeschkeLab/DeerLab'),
+  ('Other Versions and Download', 'https://pypi.org/project/DeerLab/#history')]
+-%}
+
+  <div class="container-fluid {{ top_container_cls }} px-0">
+
+    <div class="sk-navbar-collapse collapse navbar-collapse" id="navbarSupportedContent">
+      <ul class="navbar-nav mr-auto">
+        <li class="nav-item">
+          <a class="sk-nav-link nav-link" href="{{ pathto('installation') }}">Installation</a>
+        </li>
+
+        <li class="dropdown">
+          <a class="dropbtn" href="{{ pathto('user_guide') }}" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">User Guide</a>
+          <div class="dropdown-content" aria-labelledby="navbarDropdown">
+            {%- for title, link in userguide_dropdown_navigation %}
+              <a class="sk-nav-dropdown-item dropdown-item" href="{{ link }}">{{ title}}</a>
+            {%- endfor %}
+          </div>
+        </li>
+
+        <li class="dropdown">
+            <a class="dropbtn" href="{{ pathto('advanced_guide') }}" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Advanced Guides</a>
+            <div class="dropdown-content" aria-labelledby="navbarDropdown">
+              {%- for title, link in advancedguide_dropdown_navigation %}
+                <a class="sk-nav-dropdown-item dropdown-item" href="{{ link }}">{{ title}}</a>
+              {%- endfor %}
+            </div>
+          </li>
+
+        <li class="nav-item">
+          <a class="sk-nav-link nav-link" href="{{ pathto('examples') }}">Examples</a>
+        </li>
+
+        <li class="nav-item">
+          <a class="sk-nav-link nav-link" href="{{ pathto('modelsref') }}">Models</a>
+        </li>
+
+        
+        <li class="nav-item">
+            <a class="sk-nav-link nav-link" href="{{ pathto('reference') }}">Reference</a>
+          </li>
+
+        {%- for title, link in drop_down_navigation %}
+        <li class="nav-item">
+          <a class="sk-nav-link nav-link nav-more-item-mobile-items" href="{{ link }}">{{ title }}</a>
+        </li>
+
+        {%- endfor %}
+
+        <li class="dropdown">
+          <a class="dropbtn" href="{{ pathto('more') }}" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">More</a>
+          <div class="dropdown-content" aria-labelledby="navbarDropdown">
+            {%- for title, link in more_dropdown_navigation %}
+              <a class="sk-nav-dropdown-item dropdown-item" href="{{ link }}">{{ title}}</a>
+            {%- endfor %}
+          </div>
+        </li>
+      </ul>
+
+    </div>
+  </div>

--- a/docsrc/source/conf.py
+++ b/docsrc/source/conf.py
@@ -91,6 +91,8 @@ imgmath_latex_preamble = r'''
 
 # Configuration of the HTML Theme Template
 # ----------------------------------------------------------------------
+templates_path = ['_templates']
+
 # Setup template stuff
 exclude_patterns = ['.', './functions']
 numpydoc_show_class_members = False
@@ -110,6 +112,9 @@ html_context = {
     'version' : version,                                  
 }
 html_theme_options = {
+    "navbar_start": ["navbar-logo"],
+    "navbar_center": ["nav"],
+    "navbar_end": ["search-field","navbar-icon-links"],
     "icon_links": [
         {
             "name": "GitHub",
@@ -135,11 +140,11 @@ html_theme_options = {
 }
 html_sidebars = {
     "index": [],
-    "modelsref": ["search-field"],
-    "reference": ["search-field"],
-    "_autosummary/**": ["search-field"],
-    "examples": ["search-field"],
-    "auto_examples/**": ["search-field"],
+    "modelsref": [],
+    "reference": [],
+    "_autosummary/**": [],
+    "examples": [],
+    "auto_examples/**": [],
 }
 
 html_copy_source = False
@@ -262,3 +267,5 @@ rst_epilog = f"""
 
 .. |api| replace:: :raw-html:`<span class="badge changelog_api">API Change</span>`
 """
+
+

--- a/docsrc/source/index.rst
+++ b/docsrc/source/index.rst
@@ -45,7 +45,7 @@
     <div class="boxcontainer">
         <h3>Contributing</h3>
         <p>DeerLab is hosted on Github. Look at the contribution guidelines. </p>
-        <a class="boxlink" href="https://github.com/JeschkeLab/DeerLab">Contribute →</a>
+        <a class="boxlink" href="contributing.html">Contribute →</a>
     </div>     
     </div>
 

--- a/docsrc/source/license.rst
+++ b/docsrc/source/license.rst
@@ -1,0 +1,24 @@
+.. _license:
+
+License
+-------
+
+Copyright (c) 2019-2022 Luis Fabregas, Stefan Stoll, and others
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docsrc/source/support.rst
+++ b/docsrc/source/support.rst
@@ -1,9 +1,4 @@
-.. _more:
-
-More
-============================================================
-
----------------
+.. _support:
 
 Funding
 --------
@@ -50,27 +45,3 @@ DeerLab is a project that has been funded by the following sources:
         </div>
     </div>    
     
--------------------
-
-License
--------
-
-Copyright (c) 2019-2022 Luis Fabregas, Stefan Stoll, and others
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.

--- a/docsrc/source/user_guide.rst
+++ b/docsrc/source/user_guide.rst
@@ -8,7 +8,6 @@ This is the introductory guide to DeerLab for any dipolar electron paramagnetic 
 .. toctree::
     :maxdepth: 2
 
-    ./installation
     ./basics
     ./getting_started
     ./dipolar_guide_modelling


### PR DESCRIPTION
Substitutes the former navigation bar system (which required at least three levels of navigation to access the core documentation pages) to a dropdown navigation bar system (which requires a single level of navigation to access the core information). Additionally, there is a minor refactoring of the distribution of the pages. 

![image](https://user-images.githubusercontent.com/48292540/160688550-28eb8dbe-273c-4077-a4a8-f1a08b072f82.png)
