### PR TITLE
Enable the pickling of DeerLab's objects 

### DIFF
--- a/deerlab/__init__.py
+++ b/deerlab/__init__.py
@@ -19,3 +19,4 @@ from .distancerange import distancerange
 from .classes import FitResult, UQResult
 from .diststats import diststats
 from .profile_analysis import profile_analysis
+from .utils import save, load

--- a/deerlab/__init__.py
+++ b/deerlab/__init__.py
@@ -19,4 +19,4 @@ from .distancerange import distancerange
 from .classes import FitResult, UQResult
 from .diststats import diststats
 from .profile_analysis import profile_analysis
-from .utils import save, load
+from .utils import store_pickle, read_pickle

--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -178,7 +178,20 @@ class Model():
     #=======================================================================================
     #                                         Constructor
     #=======================================================================================
-
+    
+    # Use a wrapper function to facilitate internal arguments manipulation        
+    #-----------------------------------
+    def _model_with_constants(self,nonlinfcn,constantsInfo,*inputargs):
+        Nconstants = len(constantsInfo)
+        constants = inputargs[:Nconstants]
+        θ = inputargs[Nconstants:]
+        args = list(θ)
+        if constantsInfo is not None:
+            for info,constant in zip(constantsInfo,constants):
+                args.insert(info['argidx'],constant)
+        return nonlinfcn(*args)
+    #----------------------------------- 
+    
     #---------------------------------------------------------------------------------------
     def __init__(self,nonlinfcn,constants=None,signature=None): 
         """
@@ -234,21 +247,8 @@ class Model():
                 for n,par in enumerate(parameters): 
                     if par==argname: 
                         parameters.remove(argname)
-        Nconstants = len(self._constantsInfo)
-
-
-        # Use a wrapper function to facilitate internal arguments manipulation        
-        #-----------------------------------
-        def model_with_constants(*inputargs):
-            constants = inputargs[:Nconstants]
-            θ = inputargs[Nconstants:]
-            args = list(θ)
-            if self._constantsInfo is not None:
-                for info,constant in zip(self._constantsInfo,constants):
-                    args.insert(info['argidx'],constant)
-            return nonlinfcn(*args)
-        #-----------------------------------    
-        self.nonlinmodel = model_with_constants
+  
+        self.nonlinmodel = partial(self._model_with_constants,nonlinfcn,self._constantsInfo)
 
         # Update the number of parameters in the model
         self.Nparam = len(parameters)

--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -1195,7 +1195,7 @@ def _aresame(obj1,obj2):
 # ---------------------------------------------------------------------
 
 # ---------------------------------------------------------------------
-def _linked_model_with_constants(nonlinfcn,Nconstants,mapping,constantsInfo,linear_reduce_idx,*inputargs):
+def _linked_model_with_constants(nonlinfcn,mapping,constantsInfo,linear_reduce_idx,*inputargs):
     # Redistribute the input parameter vector according to the mapping vector
     Nconstants = len(constantsInfo)
     constants = inputargs[:Nconstants]

--- a/deerlab/solvers.py
+++ b/deerlab/solvers.py
@@ -13,6 +13,7 @@ import deerlab as dl
 from deerlab.classes import UQResult, FitResult
 from deerlab.utils import multistarts, hccm, parse_multidatasets, goodness_of_fit, Jacobian, isempty
 import time 
+from functools import partial
 
 def timestamp():
 # ===========================================================================================
@@ -917,9 +918,7 @@ def snlls(y, Amodel, par0=None, lb=None, ub=None, lbl=None, ubl=None, nnlsSolver
     stats = _goodness_of_fit_stats(ys,yfits,noiselvl,Ndof)
 
     # Display function
-    def plotfcn(show=False,axis=None,xlabel=None):
-        fig = _plot(ys,yfits,yuq,axis,xlabel)
-        return fig
+    plotfcn = partial(_plot,ys,yfits,yuq)
 
     if len(stats) == 1: 
         stats = stats[0]

--- a/deerlab/utils/utils.py
+++ b/deerlab/utils/utils.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 import scipy as scp
 import scipy.optimize as opt
-from types import FunctionType 
+from types import FunctionType, LambdaType
 from functools import wraps
 import pickle
 
@@ -655,15 +655,18 @@ try:
 
 except: pass
 
+import dill as pickle
 
-
+# --------------------------------------------------------------------------------------
 def save(obj, filename):
     """ Pickle object into a file. """
     if '.pkl' not in filename:
         filename = filename + '.pkl'
     with open(filename, 'wb') as outp:  # Overwrites any existing file.
         pickle.dump(obj, outp, pickle.HIGHEST_PROTOCOL)
+# --------------------------------------------------------------------------------------
 
+# --------------------------------------------------------------------------------------
 def load(filename):
     """ Deserialize a file of pickled objects. """
     if '.pkl' not in filename:
@@ -674,3 +677,4 @@ def load(filename):
                 return pickle.load(f)
             except EOFError:
                 break
+# --------------------------------------------------------------------------------------

--- a/deerlab/utils/utils.py
+++ b/deerlab/utils/utils.py
@@ -5,7 +5,7 @@ import scipy as scp
 import scipy.optimize as opt
 from types import FunctionType 
 from functools import wraps
-
+import pickle
 
 def parse_multidatasets(V_, K, weights, noiselvl, precondition=False, masks=None, subsets=None):
 #===============================================================================
@@ -654,3 +654,23 @@ try:
 
 
 except: pass
+
+
+
+def save(obj, filename):
+    """ Pickle object into a file. """
+    if '.pkl' not in filename:
+        filename = filename + '.pkl'
+    with open(filename, 'wb') as outp:  # Overwrites any existing file.
+        pickle.dump(obj, outp, pickle.HIGHEST_PROTOCOL)
+
+def load(filename):
+    """ Deserialize a file of pickled objects. """
+    if '.pkl' not in filename:
+        filename = filename + '.pkl'
+    with open(filename, "rb") as f:
+        while True:
+            try:
+                return pickle.load(f)
+            except EOFError:
+                break

--- a/deerlab/utils/utils.py
+++ b/deerlab/utils/utils.py
@@ -661,7 +661,7 @@ except: pass
 import dill as pickle
 
 # --------------------------------------------------------------------------------------
-def save(obj, filename):
+def store_pickle(obj, filename):
     """
     Save/export an object to a ``.pkl`` file serialized as bytes.
     
@@ -680,14 +680,18 @@ def save(obj, filename):
 # --------------------------------------------------------------------------------------
 
 # --------------------------------------------------------------------------------------
-def load(filename):
+def read_pickle(filename):
     """
     Load a pickled object file ``.pkl`` and deserialize the bytes into a Python object.
     
     Parameters
     ----------
     filename : string 
-        Name (and path) of the ``.pkl`` file to load.
+        Path to the ``.pkl`` file to load.
+
+
+    .. warning:: Loading pickled data received from untrusted sources can be unsafe. See `here<https://docs.python.org/3/library/pickle.html>`_.
+
     """ 
     if '.pkl' not in filename:
         filename = filename + '.pkl'

--- a/deerlab/utils/utils.py
+++ b/deerlab/utils/utils.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 import scipy as scp
 import scipy.optimize as opt
-from types import FunctionType, LambdaType
+from types import FunctionType
 from functools import wraps
 import pickle
 

--- a/deerlab/utils/utils.py
+++ b/deerlab/utils/utils.py
@@ -659,7 +659,17 @@ import dill as pickle
 
 # --------------------------------------------------------------------------------------
 def save(obj, filename):
-    """ Pickle object into a file. """
+    """
+    Save/export an object to a ``.pkl`` file serialized as bytes.
+    
+    Parameters
+    ----------
+    obj : object 
+        Python object to be saved/exported. 
+
+    filename : string 
+        Name (and path) of the file to save the pickled object to. The object is saved as a ``.pkl`` file. 
+    """   
     if '.pkl' not in filename:
         filename = filename + '.pkl'
     with open(filename, 'wb') as outp:  # Overwrites any existing file.
@@ -668,7 +678,14 @@ def save(obj, filename):
 
 # --------------------------------------------------------------------------------------
 def load(filename):
-    """ Deserialize a file of pickled objects. """
+    """
+    Load a pickled object file ``.pkl`` and deserialize the bytes into a Python object.
+    
+    Parameters
+    ----------
+    filename : string 
+        Name (and path) of the ``.pkl`` file to load.
+    """ 
     if '.pkl' not in filename:
         filename = filename + '.pkl'
     with open(filename, "rb") as f:

--- a/docsrc/source/changelog.rst
+++ b/docsrc/source/changelog.rst
@@ -102,9 +102,9 @@ Release v0.14.0 - April 2022
 - |fix| Prompts error if wrong method is selected when specifying a limited excitation bandwidth (:issue:`181`, :pr:`183`). 
 
 .. rubric:: ``bg_models``
-- |feature| Implemented the time-dependent phase shifts for all the built-in physical background models, namely `bg_hon3d_phase`, `bg_hom3dex_phase`, and `bg_homfractal_phase` (:pr:`258`).   
-- |enhancement| Changed the implementation of `bg_hom3dex` (:pr:`258`). This avoids the use of tabulated pre-calculated values. Accordingly the utility functions `calculate_exvolume_redfactor` and `load_exvolume_redfactor` have been removed.
-- |fix| Improved the implementation and behavior of the `bg_homfractal` model (:pr:`258`).
+- |feature| Implemented the time-dependent phase shifts for all the built-in physical background models, namely ``bg_hon3d_phase``, ``bg_hom3dex_phase``, and ``bg_homfractal_phase`` (:pr:`258`).   
+- |enhancement| Changed the implementation of ``bg_hom3dex`` (:pr:`258`). This avoids the use of tabulated pre-calculated values. Accordingly the utility functions ``calculate_exvolume_redfactor`` and ``load_exvolume_redfactor`` have been removed.
+- |fix| Improved the implementation and behavior of the ``bg_homfractal`` model (:pr:`258`).
 
 .. rubric:: ``diststats``
 - |fix| Fixed the behavior when dealing with distributions with arbitrary integral values

--- a/docsrc/source/installation.rst
+++ b/docsrc/source/installation.rst
@@ -44,6 +44,7 @@ DeerLab installs the following packages:
 * `scipy <https://www.scipy.org/>`_ - Fundamental library for scientific computing
 * `joblib <https://joblib.readthedocs.io/en/latest/>`_ - Library lightweight pipelining and parallelization.
 * `tqdm <https://github.com/tqdm/tqdm>`_ - A lightweight package for smart progress meters.
+* `dill <https://github.com/uqfoundation/dill>`_ - An extension of Python's pickle module for serializing and de-serializing python objects.
 
 The installed numerical computing packages (numpy, scipy, cvxopt) are linked against different BLAS libraries depending on the OS:
 

--- a/docsrc/source/reference.rst
+++ b/docsrc/source/reference.rst
@@ -45,7 +45,9 @@ API Reference
     snlls 
     fnnls
     cvxnnls
-
+    save
+    load 
+    
 .. rubric:: Dipolar EPR functions
 
 .. autosummary::

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def install_dependencies(develop_mode=False):
     # able to be handled by pip automatically. 
 
     # DeerLab dependencies on the PyPI
-    dependencies = ["memoization","matplotlib","tqdm","joblib"] 
+    dependencies = ["memoization","matplotlib","tqdm","joblib","dill"] 
 
     if platform.system() == 'Windows':
         # Use own forked pipwin repo for self-patched fixes 

--- a/test/test_model_class.py
+++ b/test/test_model_class.py
@@ -1105,9 +1105,9 @@ def test_pickle_fitresult():
     "Check that the fit results object can be pickled"
 
     fitResult = fit(mymodel,y)
-    save(fitResult,'pickled_results')
+    store_pickle(fitResult,'pickled_results')
     try:
-        pickled_fitResult = load('pickled_results')
+        pickled_fitResult =read_pickle('pickled_results')
         os.remove("pickled_results.pkl") 
         assert np.allclose(pickled_fitResult.model.real,y.real) and np.allclose(pickled_fitResult.model.imag,y.imag)
     except Exception as exception:
@@ -1119,9 +1119,9 @@ def test_pickle_model():
 # ======================================================================
     "Check that the model object can be pickled"
 
-    save(mymodel,'pickled_model')
+    store_pickle(mymodel,'pickled_model')
     try:
-        pickled_model = load('pickled_model')
+        pickled_model =read_pickle('pickled_model')
         fitResult = fit(pickled_model,y)
         os.remove("pickled_model.pkl") 
         assert np.allclose(fitResult.model.real,y.real) and np.allclose(fitResult.model.imag,y.imag)

--- a/test/test_model_class.py
+++ b/test/test_model_class.py
@@ -4,7 +4,7 @@ from deerlab.model import Model, fit
 import numpy as np 
 import pytest
 import os 
-from deerlab.utils import load,save
+from deerlab.utils import store_pickle, read_pickle
 
 # Simple non-linear function for testing
 x = np.linspace(0,5,100)

--- a/test/test_model_class.py
+++ b/test/test_model_class.py
@@ -1114,3 +1114,18 @@ def test_pickle_fitresult():
         os.remove("pickled_results.pkl") 
         raise exception
 # ======================================================================
+
+def test_pickle_model():
+# ======================================================================
+    "Check that the model object can be pickled"
+
+    save(mymodel,'pickled_model')
+    try:
+        pickled_model = load('pickled_model')
+        fitResult = fit(pickled_model,y)
+        os.remove("pickled_model.pkl") 
+        assert np.allclose(fitResult.model.real,y.real) and np.allclose(fitResult.model.imag,y.imag)
+    except Exception as exception:
+        os.remove("pickled_model.pkl") 
+        raise exception
+# ======================================================================

--- a/test/test_model_class.py
+++ b/test/test_model_class.py
@@ -3,6 +3,8 @@ from deerlab.whitegaussnoise import whitegaussnoise
 from deerlab.model import Model, fit
 import numpy as np 
 import pytest
+import os 
+from deerlab.utils import load,save
 
 # Simple non-linear function for testing
 x = np.linspace(0,5,100)
@@ -1097,3 +1099,15 @@ def test_fit_propagate_callable_bootstrapped():
 
     assert_cis(modeluq)
 #================================================================
+
+def test_pickle_fitresult():
+# ======================================================================
+    "Check that the fit results object can be pickled"
+
+    fitResult = fit(mymodel,y)
+    save(fitResult,'pickled_results')
+    pickled_fitResult = load('pickled_results')
+    os.remove("pickled_results.pkl") 
+
+    assert np.allclose(pickled_fitResult.model.real,y.real) and np.allclose(pickled_fitResult.model.imag,y.imag)
+# ======================================================================

--- a/test/test_model_class.py
+++ b/test/test_model_class.py
@@ -1106,8 +1106,11 @@ def test_pickle_fitresult():
 
     fitResult = fit(mymodel,y)
     save(fitResult,'pickled_results')
-    pickled_fitResult = load('pickled_results')
-    os.remove("pickled_results.pkl") 
-
-    assert np.allclose(pickled_fitResult.model.real,y.real) and np.allclose(pickled_fitResult.model.imag,y.imag)
+    try:
+        pickled_fitResult = load('pickled_results')
+        os.remove("pickled_results.pkl") 
+        assert np.allclose(pickled_fitResult.model.real,y.real) and np.allclose(pickled_fitResult.model.imag,y.imag)
+    except Exception as exception:
+        os.remove("pickled_results.pkl") 
+        raise exception
 # ======================================================================

--- a/test/test_model_lincombine.py
+++ b/test/test_model_lincombine.py
@@ -1,7 +1,7 @@
 import numpy as np
 import deerlab as dl 
 from deerlab.model import Model,fit,lincombine
-from deerlab.utils import save, load  
+from deerlab.utils import store_pickle, read_pickle  
 import os 
 
 # ======================================================================

--- a/test/test_model_lincombine.py
+++ b/test/test_model_lincombine.py
@@ -1,6 +1,8 @@
 import numpy as np
 import deerlab as dl 
 from deerlab.model import Model,fit,lincombine
+from deerlab.utils import save, load  
+import os 
 
 # ======================================================================
 def test_type(): 
@@ -413,4 +415,26 @@ def test_vec_twomodels_normalization_values():
     results = fit(model,ref,x,x)
 
     assert np.isclose(results.Pvec_2_scale,scale2)
+# ======================================================================
+
+def test_pickle_lincombined_model():
+# ======================================================================
+    "Check that the model object can be pickled"
+    model1 = dl.dd_gauss
+    model2 = dl.dd_rice
+    x = np.linspace(0,10,100)
+    truth = model1(x,3,0.2)+model2(x,4,0.5)
+    model = lincombine(model1,model2)
+    model.mean_1.par0=3
+    model.location_2.par0=4
+    save(model,'pickled_model')
+    try:
+        pickled_model = load('pickled_model')
+        result = fit(pickled_model,truth,x,x)
+
+        os.remove("pickled_model.pkl") 
+        assert np.allclose(result.model,truth)
+    except Exception as exception:
+        os.remove("pickled_model.pkl") 
+        raise exception
 # ======================================================================

--- a/test/test_model_lincombine.py
+++ b/test/test_model_lincombine.py
@@ -427,9 +427,9 @@ def test_pickle_lincombined_model():
     model = lincombine(model1,model2)
     model.mean_1.par0=3
     model.location_2.par0=4
-    save(model,'pickled_model')
+    store_pickle(model,'pickled_model')
     try:
-        pickled_model = load('pickled_model')
+        pickled_model =read_pickle('pickled_model')
         result = fit(pickled_model,truth,x,x)
 
         os.remove("pickled_model.pkl") 

--- a/test/test_model_link.py
+++ b/test/test_model_link.py
@@ -1,7 +1,7 @@
 import numpy as np
 import deerlab as dl 
 from deerlab.model import fit,link,Model
-from deerlab.utils import save, load 
+from deerlab.utils import store_pickle, read_pickle 
 import os  
 
 # ======================================================================

--- a/test/test_model_link.py
+++ b/test/test_model_link.py
@@ -197,9 +197,9 @@ def test_pickle_linked_model():
                 std=['std1','std2'])
     linkedmodel.mean.par0 = 3
     linkedmodel.std.par0 = 0.5
-    save(linkedmodel,'pickled_model')
+    store_pickle(linkedmodel,'pickled_model')
     try:
-        pickled_model = load('pickled_model')
+        pickled_model =read_pickle('pickled_model')
         result = fit(pickled_model,ref,x, reg=False)
 
         os.remove("pickled_model.pkl") 

--- a/test/test_model_link.py
+++ b/test/test_model_link.py
@@ -1,6 +1,8 @@
 import numpy as np
 import deerlab as dl 
 from deerlab.model import fit,link,Model
+from deerlab.utils import save, load 
+import os  
 
 # ======================================================================
 def test_link_name(): 
@@ -184,3 +186,25 @@ def test_vec_link_fit():
     assert np.allclose(result.model,ref,atol=1e-2)
 # ======================================================================
 
+def test_pickle_linked_model():
+# ======================================================================
+    "Check that the model object can be pickled"
+    model = dl.dd_gauss2
+    x = np.linspace(0,10,400)
+    ref = model(x,3,0.5,3,0.5,1,1)
+    linkedmodel = link(model,
+                mean=['mean1','mean2'],
+                std=['std1','std2'])
+    linkedmodel.mean.par0 = 3
+    linkedmodel.std.par0 = 0.5
+    save(linkedmodel,'pickled_model')
+    try:
+        pickled_model = load('pickled_model')
+        result = fit(pickled_model,ref,x, reg=False)
+
+        os.remove("pickled_model.pkl") 
+        assert np.allclose(result.model,ref,atol=1e-5)
+    except Exception as exception:
+        os.remove("pickled_model.pkl") 
+        raise exception
+# ======================================================================

--- a/test/test_model_merge.py
+++ b/test/test_model_merge.py
@@ -1,6 +1,8 @@
 import numpy as np
 import deerlab as dl 
 from deerlab.model import Model,fit,merge
+from deerlab.utils import save, load
+import os 
 
 # ======================================================================
 def test_type(): 
@@ -411,4 +413,23 @@ def test_twomodels_equal_global():
     assert np.allclose(result.model,truth,globalresult.model) and np.allclose(result.mean,globalresult.mean_1)
 # ======================================================================
 
+def test_pickle_merged_model():
+# ======================================================================
+    "Check that the model object can be pickled"
+    model1 = dl.dd_gauss
+    model2 = dl.dd_rice
+    x = np.linspace(0,10,100)
+    truth = [model1(x,3,0.2),
+            model2(x,4,0.5)]
+    model = merge(model1,model2)
+    save(model,'pickled_model')
+    try:
+        pickled_model = load('pickled_model')
+        result = fit(pickled_model,truth,x,x,weights=[1,1])
 
+        os.remove("pickled_model.pkl") 
+        assert np.allclose(result.model[0],truth[0]) and np.allclose(result.model[1],truth[1])
+    except Exception as exception:
+        os.remove("pickled_model.pkl") 
+        raise exception
+# ======================================================================

--- a/test/test_model_merge.py
+++ b/test/test_model_merge.py
@@ -1,7 +1,7 @@
 import numpy as np
 import deerlab as dl 
 from deerlab.model import Model,fit,merge
-from deerlab.utils import save, load
+from deerlab.utils import store_pickle, read_pickle
 import os 
 
 # ======================================================================

--- a/test/test_model_merge.py
+++ b/test/test_model_merge.py
@@ -422,9 +422,9 @@ def test_pickle_merged_model():
     truth = [model1(x,3,0.2),
             model2(x,4,0.5)]
     model = merge(model1,model2)
-    save(model,'pickled_model')
+    store_pickle(model,'pickled_model')
     try:
-        pickled_model = load('pickled_model')
+        pickled_model =read_pickle('pickled_model')
         result = fit(pickled_model,truth,x,x,weights=[1,1])
 
         os.remove("pickled_model.pkl") 

--- a/test/test_model_relate.py
+++ b/test/test_model_relate.py
@@ -1,7 +1,10 @@
 import numpy as np
 import deerlab as dl 
 from deerlab.model import Model,fit,relate
+from deerlab.utils import save, load 
 from copy import deepcopy
+import os 
+
 # ======================================================================
 def test_type(): 
     "Check that the function returns a valid model type"
@@ -170,5 +173,26 @@ def test_relate_conflict_order():
     response2 = conflictmodel(r=x,mean1=4,mean2=5,amp1=1,amp2=1)
 
     assert np.allclose(response1,ref) and np.allclose(response2,ref)
+# ======================================================================
+
+
+def test_pickle_linked_model():
+# ======================================================================
+    "Check that the model object can be pickled"
+    model = dl.dd_gauss
+    x = np.linspace(0,10,400)
+    ref = model(x,4,0.2)
+    newmodel = relate(model, std = lambda mean: mean/20)
+
+    save(newmodel,'pickled_model')
+    try:
+        pickled_model = load('pickled_model')
+        result = fit(pickled_model,ref,x)
+
+        os.remove("pickled_model.pkl") 
+        assert np.allclose(result.model,ref)
+    except Exception as exception:
+        os.remove("pickled_model.pkl") 
+        raise exception
 # ======================================================================
 

--- a/test/test_model_relate.py
+++ b/test/test_model_relate.py
@@ -1,7 +1,7 @@
 import numpy as np
 import deerlab as dl 
 from deerlab.model import Model,fit,relate
-from deerlab.utils import save, load 
+from deerlab.utils import store_pickle, read_pickle 
 from copy import deepcopy
 import os 
 

--- a/test/test_model_relate.py
+++ b/test/test_model_relate.py
@@ -184,9 +184,9 @@ def test_pickle_linked_model():
     ref = model(x,4,0.2)
     newmodel = relate(model, std = lambda mean: mean/20)
 
-    save(newmodel,'pickled_model')
+    store_pickle(newmodel,'pickled_model')
     try:
-        pickled_model = load('pickled_model')
+        pickled_model =read_pickle('pickled_model')
         result = fit(pickled_model,ref,x)
 
         os.remove("pickled_model.pkl") 

--- a/test/test_snlls.py
+++ b/test/test_snlls.py
@@ -430,7 +430,7 @@ def test_plot():
     lbl = np.zeros(len(r))
     # Separable LSQ fit
     fit = snlls(V,lambda lam: dipolarkernel(t,r,mod=lam),par0=0.2,lb=0,ub=1,lbl=lbl, uq=False)
-    fig = fit.plot(show=False)
+    fig = fit.plot()
     
     assert str(fig.__class__)=="<class 'matplotlib.figure.Figure'>"
 # ======================================================================

--- a/test/test_snlls_nlls.py
+++ b/test/test_snlls_nlls.py
@@ -189,7 +189,7 @@ def test_plot():
     model = lambda p: K@dd_gauss(r,*p)
     fit = snlls(V,model,par0,lb,ub)
     
-    fig = fit.plot(show=False)
+    fig = fit.plot()
     assert str(fig.__class__)=="<class 'matplotlib.figure.Figure'>"
 # ======================================================================
 

--- a/test/test_snlls_rlls.py
+++ b/test/test_snlls_rlls.py
@@ -238,7 +238,7 @@ def test_plot():
     V = K@P
 
     fit = snlls(V,K,lbl=np.zeros_like(r))
-    fig = fit.plot(show=False)
+    fig = fit.plot()
     assert str(fig.__class__)=="<class 'matplotlib.figure.Figure'>"
 #============================================================
 


### PR DESCRIPTION
## Features
- Refactor the code to avoid the use of `lambda` and nested functions. This enables pickling with Python's `pickle` module without errors. 
- Add two new utility functions `save` and `load` that implement pickling with the `dill` package to be more robust against potential `lambda` functions defined by the users in scripts.  
- Add tests to check that pickling of the `FitResult` and `Model` objects are successful.

With this PR users will be able to store both models and fit results to files and access both the data and functions in those objects from the files without the need to re-run the scripts that generated them. 

It also contributes towards the conformity of DeerLab's code with PEP8 guidelines as discussed in #306 