### PR TITLE
Fix build and upload of a release to PyPI

### DIFF
--- a/.github/workflows/package_upload.yml
+++ b/.github/workflows/package_upload.yml
@@ -20,10 +20,9 @@ jobs:
           python -m pip install setuptools --user
           python -m pip install build --user
           python -m pip install twine --user
-    - name: PyPI - Build and publish
+    - name: Build distribution
       run: |
           python setup.py sdist
-          python -m twine upload dist/*
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:


### PR DESCRIPTION
Removes the twine-upload line that should have been deleted last time the workflow was edited. The upload is now done via the PyPI API with a third-party Action.

This error caused the crash of the PyPI upload after the release of v0.14.0. Closes #308 