### PR TITLE
Correct behavior of L-curve selection methods

### DIFF
--- a/deerlab/selregparam.py
+++ b/deerlab/selregparam.py
@@ -155,8 +155,7 @@ def selregparam(y, A, solver, method='aic', algorithm='brent', noiselvl=None,
             Rho = np.log(np.asarray(residuals)+1e-20)
             dd = lambda x: (x-np.min(x))/(np.max(x)-np.min(x))
             functional = dd(Rho)**2 + dd(Eta)**2         
-            functional = functional # Maximize instead of minimize 
-
+            
         # L-curve maximum-curvature method (LC)
         elif method == 'lc': 
             d1Residual = np.gradient(np.log(np.asarray(residuals)+1e-20))

--- a/deerlab/selregparam.py
+++ b/deerlab/selregparam.py
@@ -151,23 +151,23 @@ def selregparam(y, A, solver, method='aic', algorithm='brent', noiselvl=None,
         
         # L-curve minimum-radius method (LR)
         if method == 'lr':
-            Eta = np.log(penalties)
-            Rho = np.log(residuals)
+            Eta = np.log(np.asarray(penalties)+1e-20)
+            Rho = np.log(np.asarray(residuals)+1e-20)
             dd = lambda x: (x-np.min(x))/(np.max(x)-np.min(x))
             functional = dd(Rho)**2 + dd(Eta)**2         
+            functional = functional # Maximize instead of minimize 
 
         # L-curve maximum-curvature method (LC)
         elif method == 'lc': 
-            d1Residual = np.gradient(np.log(residuals))
+            d1Residual = np.gradient(np.log(np.asarray(residuals)+1e-20))
             d2Residual = np.gradient(d1Residual)
-            d1Penalty = np.gradient(np.log(penalties))
+            d1Penalty = np.gradient(np.log(np.asarray(penalties)+1e-20))
             d2Penalty = np.gradient(d1Penalty)
             functional = (d1Residual*d2Penalty - d2Residual*d1Penalty)/(d1Residual**2 + d1Penalty**2)**(3/2)
             functional = -functional # Maximize instead of minimize 
 
         # Find minimum of the selection functional              
         alphaOpt = alphaCandidates[np.argmin(functional)]
-
     else: 
         raise KeyError("Search method not found. Must be either 'brent' or 'grid'.")
 

--- a/deerlab/selregparam.py
+++ b/deerlab/selregparam.py
@@ -163,6 +163,7 @@ def selregparam(y, A, solver, method='aic', algorithm='brent', noiselvl=None,
             d1Penalty = np.gradient(np.log(penalties))
             d2Penalty = np.gradient(d1Penalty)
             functional = (d1Residual*d2Penalty - d2Residual*d1Penalty)/(d1Residual**2 + d1Penalty**2)**(3/2)
+            functional = -functional # Maximize instead of minimize 
 
         # Find minimum of the selection functional              
         alphaOpt = alphaCandidates[np.argmin(functional)]

--- a/test/test_selregparam.py
+++ b/test/test_selregparam.py
@@ -175,7 +175,7 @@ def test_lc_value():
     "Check that the value returned by the LC selection method is correct"
     
     loga = get_alpha_from_method('lc')
-    logaref = -7.900  # Computed with DeerLab-Matlab (0.9.2)
+    logaref = -1.39
 
     assert abs(1-loga/logaref) < 0.20
 #=======================================================================


### PR DESCRIPTION
- Fix the behavior of the `lc` method for L-curve regularization parameter selection in `selregparam`. The method was seeking the regularization parameter by minimizing the curvature of the L-curve instead of maximizing it. Correct the related test.
- Prevent the case `np.log(0) = np.inf` from occurring when evaluating too large regularization parameter values that would end up with full-zero penalty terms. 