### PR TITLE
Fix documentation navigation menu on mobile phones and collapsed windows and other edits

### DIFF
--- a/docsrc/source/_static/theme_override.css
+++ b/docsrc/source/_static/theme_override.css
@@ -9373,6 +9373,7 @@ font-weight: 600;
 color: var(--main-color);
 background-color: transparent;
 border-left: 2px solid var(--main-color);
+border-radius: 0px;
 }
 .toc-h2 {
 font-size:.85rem

--- a/docsrc/source/_templates/nav.html
+++ b/docsrc/source/_templates/nav.html
@@ -1,3 +1,4 @@
+
 {%- set userguide_dropdown_navigation = [
     ('Basics', pathto('basics')),
     ('Getting Started', pathto('getting_started')),
@@ -5,7 +6,6 @@
     ('Fitting', pathto('dipolar_guide_fitting')),
     ('Theory', pathto('theory')),]
   -%}
-  
 
 {%- set advancedguide_dropdown_navigation = [
 ('Modelling Guide', pathto('modelling_guide')),
@@ -23,18 +23,18 @@
 -%}
 
   <div class="container-fluid {{ top_container_cls }} px-0">
-
-    <div class="sk-navbar-collapse collapse navbar-collapse" id="navbarSupportedContent">
+  
+    <div class="navbar-collapse collapse navbar-collapse" id="navbar-collapsible">
       <ul class="navbar-nav mr-auto">
         <li class="nav-item">
-          <a class="sk-nav-link nav-link" href="{{ pathto('installation') }}">Installation</a>
+          <a class="nav-link nav-link" href="{{ pathto('installation') }}">Installation</a>
         </li>
 
         <li class="dropdown">
           <a class="dropbtn" href="{{ pathto('user_guide') }}" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">User Guide</a>
           <div class="dropdown-content" aria-labelledby="navbarDropdown">
             {%- for title, link in userguide_dropdown_navigation %}
-              <a class="sk-nav-dropdown-item dropdown-item" href="{{ link }}">{{ title}}</a>
+              <a class="nav-dropdown-item dropdown-item" href="{{ link }}">{{ title}}</a>
             {%- endfor %}
           </div>
         </li>
@@ -43,36 +43,36 @@
             <a class="dropbtn" href="{{ pathto('advanced_guide') }}" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Advanced Guides</a>
             <div class="dropdown-content" aria-labelledby="navbarDropdown">
               {%- for title, link in advancedguide_dropdown_navigation %}
-                <a class="sk-nav-dropdown-item dropdown-item" href="{{ link }}">{{ title}}</a>
+                <a class="nav-dropdown-item dropdown-item" href="{{ link }}">{{ title}}</a>
               {%- endfor %}
             </div>
           </li>
 
         <li class="nav-item">
-          <a class="sk-nav-link nav-link" href="{{ pathto('examples') }}">Examples</a>
+          <a class="nav-link nav-link" href="{{ pathto('examples') }}">Examples</a>
         </li>
 
         <li class="nav-item">
-          <a class="sk-nav-link nav-link" href="{{ pathto('modelsref') }}">Models</a>
+          <a class="nav-link nav-link" href="{{ pathto('modelsref') }}">Models</a>
         </li>
 
         
         <li class="nav-item">
-            <a class="sk-nav-link nav-link" href="{{ pathto('reference') }}">Reference</a>
+            <a class="nav-link nav-link" href="{{ pathto('reference') }}">Reference</a>
           </li>
 
         {%- for title, link in drop_down_navigation %}
         <li class="nav-item">
-          <a class="sk-nav-link nav-link nav-more-item-mobile-items" href="{{ link }}">{{ title }}</a>
+          <a class="nav-link nav-link nav-more-item-mobile-items" href="{{ link }}">{{ title }}</a>
         </li>
 
         {%- endfor %}
 
         <li class="dropdown">
-          <a class="dropbtn" href="{{ pathto('more') }}" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">More</a>
+          <a class="dropbtn nav-link dropdown-toggle" href="{{ pathto('more') }}" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">More</a>
           <div class="dropdown-content" aria-labelledby="navbarDropdown">
             {%- for title, link in more_dropdown_navigation %}
-              <a class="sk-nav-dropdown-item dropdown-item" href="{{ link }}">{{ title}}</a>
+              <a class="nav-dropdown-item dropdown-item" href="{{ link }}">{{ title}}</a>
             {%- endfor %}
           </div>
         </li>

--- a/docsrc/source/conf.py
+++ b/docsrc/source/conf.py
@@ -114,7 +114,7 @@ html_context = {
 html_theme_options = {
     "navbar_start": ["navbar-logo"],
     "navbar_center": ["nav"],
-    "navbar_end": ["search-field","navbar-icon-links"],
+    "navbar_end": ["search-field"],
 }
 html_sidebars = {
     "index": [],
@@ -124,8 +124,8 @@ html_sidebars = {
     "examples": [],
     "auto_examples/**": [],
     "auto_examples/**": [],
-    "**": ["sidebar-nav-bs", "sidebar-ethical-ads"],
-    "page_sidebar_items": ["page-toc", "edit-this-page"],
+    "**": ["sidebar-nav-bs"],
+    "page_sidebar_items": ["page-toc"],
 }
 
 html_copy_source = False

--- a/docsrc/source/reference.rst
+++ b/docsrc/source/reference.rst
@@ -45,8 +45,6 @@ API Reference
     snlls 
     fnnls
     cvxnnls
-    save
-    load 
     
 .. rubric:: Dipolar EPR functions
 


### PR DESCRIPTION
- Fixes the navigation menu on mobile phones and collapsed windows on PC. The navigation menu was showing up empty after pressing the menu button. 
- Other minor edits to suppress Sphinx warnings and CSS fixes