### PR TITLE
Fix errors in GHA publishing workflow

### DIFF
--- a/.github/workflows/docs_PR.yml
+++ b/.github/workflows/docs_PR.yml
@@ -11,7 +11,7 @@ on:
     - '.github/workflows/examples_PR.yml'
 jobs:
 
-  deploy:
+  docsbuild:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/package_upload.yml
+++ b/.github/workflows/package_upload.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build distribution
       run: |
           python setup.py sdist
-          ./setup.py bdist_wheel
+          ./setup.py bdist_wheel --user
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
@@ -53,4 +53,4 @@ jobs:
         subdir: 'conda.recipe'
         anacondatoken: ${{ secrets.ANACONDA_TOKEN }}
         platforms: 'osx-64 linux-32 linux-64 win-32 win-64'
-        python: '3.6 3.7 3.8 3.9 3.10'
+        python: '3.8 3.9 3.10'


### PR DESCRIPTION
- Fixes uploading to PyPI and Anaconda 
- Deprecates conda support for Python 3.6 and 3.7