### PR TITLE
`dipolarmodel`: Add `pulselength` optional argument to experiment models

### DIFF
--- a/deerlab/dipolarmodel.py
+++ b/deerlab/dipolarmodel.py
@@ -237,8 +237,8 @@ def dipolarmodel(t, r, Pmodel=None, Bmodel=bg_hom3d, npathways=1, harmonics=None
         for n in range(npathways):
             getattr(DipolarSignal,reftime_names[n]).set(
                 par0 = experiment.reftimes[n],
-                lb = experiment.reftimes[n] - 0.05,
-                ub = experiment.reftimes[n] + 0.05
+                lb = experiment.reftimes[n] - 3*experiment.pulselength,
+                ub = experiment.reftimes[n] + 3*experiment.pulselength
                 )
 
     # Set other dipolar model specific attributes
@@ -337,15 +337,16 @@ class ExperimentInfo():
     r"""
     Represents information about a dipolar EPR experiment"""
 
-    def __init__(self,name,reftimes,harmonics):
+    def __init__(self,name,reftimes,harmonics,pulselength):
         self.npathways = len(reftimes)
         self.reftimes = reftimes
         self.harmonics = harmonics
+        self.pulselength = pulselength
         self.name = name
 #===============================================================================
 
 #===============================================================================
-def ex_3pdeer(tau, pathways=None):
+def ex_3pdeer(tau, pathways=None, pulselength=0.016):
     r"""
     Generate a 3-pulse DEER dipolar experiment model. 
 
@@ -375,6 +376,10 @@ def ex_3pdeer(tau, pathways=None):
         Pathways to include in the model. The pathways are specified based to the pathways numbers. 
         By default, both pathways are included in the order given in the table above.
 
+    pulselength : float scalar, optional 
+        Length of the longest microwave pulse in the sequence in microseconds. Used to determine the uncertainty in the 
+        boundaries of the pathay refocusing times.
+
     Returns
     -------
     experiment : ``ExperimentInfo`` object
@@ -394,11 +399,11 @@ def ex_3pdeer(tau, pathways=None):
         reftimes = [reftimes[pathway-1] for pathway in pathways]
         harmonics = [harmonics[pathway-1] for pathway in pathways] 
 
-    return ExperimentInfo('3-pulse DEER',reftimes,harmonics)
+    return ExperimentInfo('3-pulse DEER',reftimes,harmonics,pulselength)
 #===============================================================================
 
 #===============================================================================
-def ex_4pdeer(tau1, tau2, pathways=None):
+def ex_4pdeer(tau1, tau2, pathways=None, pulselength=0.016):
     r"""
     Generate a 4-pulse DEER dipolar experiment model. 
     
@@ -432,6 +437,10 @@ def ex_4pdeer(tau1, tau2, pathways=None):
         Pathways to include in the model. The pathways are specified based to the pathways numbers. 
         By default, all 4 pathways are included in the order given in the table above.
 
+    pulselength : float scalar, optional 
+        Length of the longest microwave pulse in the sequence in microseconds. Used to determine the uncertainty in the 
+        boundaries of the pathay refocusing times.
+
     Returns
     -------
     experiment : ``ExperimentInfo`` object
@@ -450,11 +459,11 @@ def ex_4pdeer(tau1, tau2, pathways=None):
         reftimes = [reftimes[pathway-1] for pathway in pathways]
         harmonics = [harmonics[pathway-1] for pathway in pathways] 
 
-    return ExperimentInfo('4-pulse DEER', reftimes, harmonics)
+    return ExperimentInfo('4-pulse DEER', reftimes, harmonics, pulselength)
 #===============================================================================
 
 #===============================================================================
-def ex_rev5pdeer(tau1, tau2, tau3, pathways=None):
+def ex_rev5pdeer(tau1, tau2, tau3, pathways=None, pulselength=0.016):
     r"""
     Generate a reverse 5-pulse DEER dipolar experiment model. 
     
@@ -494,6 +503,10 @@ def ex_rev5pdeer(tau1, tau2, tau3, pathways=None):
         Pathways to include in the model. The pathways are specified based to the pathways numbers. 
         By default, all 8 pathways are included in the order given in the table above.
 
+    pulselength : float scalar, optional 
+        Length of the longest microwave pulse in the sequence in microseconds. Used to determine the uncertainty in the 
+        boundaries of the pathay refocusing times.
+
     Returns
     -------
     experiment : ``ExperimentInfo`` object
@@ -512,12 +525,12 @@ def ex_rev5pdeer(tau1, tau2, tau3, pathways=None):
         reftimes = [reftimes[pathway-1] for pathway in pathways]
         harmonics = [harmonics[pathway-1] for pathway in pathways]
     
-    return ExperimentInfo('Reverse 5-pulse DEER',reftimes,harmonics)
+    return ExperimentInfo('Reverse 5-pulse DEER',reftimes,harmonics,pulselength)
 #===============================================================================
 
 
 #===============================================================================
-def ex_fwd5pdeer(tau1, tau2, tau3, pathways=None):
+def ex_fwd5pdeer(tau1, tau2, tau3, pathways=None, pulselength=0.016):
     r"""
     Generate a forward 5-pulse DEER dipolar experiment model. 
     
@@ -557,6 +570,10 @@ def ex_fwd5pdeer(tau1, tau2, tau3, pathways=None):
         Pathways to include in the model. The pathways are specified based to the pathways numbers. 
         By default, all pathways are included in the order given in the table above.
 
+    pulselength : float scalar, optional 
+        Length of the longest microwave pulse in the sequence in microseconds. Used to determine the uncertainty in the 
+        boundaries of the pathay refocusing times.
+
     Returns
     -------
     experiment : ``ExperimentInfo`` object
@@ -575,11 +592,11 @@ def ex_fwd5pdeer(tau1, tau2, tau3, pathways=None):
         reftimes = [reftimes[pathway-1] for pathway in pathways]
         harmonics = [harmonics[pathway-1] for pathway in pathways] 
 
-    return ExperimentInfo('Forward 5-pulse DEER', reftimes, harmonics)
+    return ExperimentInfo('Forward 5-pulse DEER',reftimes,harmonics,pulselength)
 #===============================================================================
 
 #===============================================================================
-def ex_sifter(tau1, tau2, pathways=None):
+def ex_sifter(tau1, tau2, pathways=None, pulselength=0.016):
     r"""
     Generate a SIFTER dipolar experiment model. 
 
@@ -611,6 +628,10 @@ def ex_sifter(tau1, tau2, pathways=None):
         Pathways to include in the model. The pathways are specified based to the pathways numbers. 
         By default, all 3 pathways are included and ordered as given in the table above.
 
+    pulselength : float scalar, optional 
+        Length of the longest microwave pulse in the sequence in microseconds. Used to determine the uncertainty in the 
+        boundaries of the pathay refocusing times.
+
     Returns
     -------
     experiment : ``ExperimentInfo`` object
@@ -630,12 +651,12 @@ def ex_sifter(tau1, tau2, pathways=None):
         reftimes = [reftimes[pathway-1] for pathway in pathways]
         harmonics = [harmonics[pathway-1] for pathway in pathways]
 
-    return ExperimentInfo('SIFTER',reftimes,harmonics)
+    return ExperimentInfo('SIFTER',reftimes,harmonics,pulselength)
 #===============================================================================
 
 
 #===============================================================================
-def ex_ridme(tau1, tau2, pathways=None):
+def ex_ridme(tau1, tau2, pathways=None, pulselength=0.016):
     r"""
     Generate a RIDME dipolar experiment model. 
 
@@ -668,6 +689,10 @@ def ex_ridme(tau1, tau2, pathways=None):
         Pathways to include in the model. The pathways are specified based to the pathways numbers. 
         By default, all 4 pathways are included in the order given in the table above.
 
+    pulselength : float scalar, optional 
+        Length of the longest microwave pulse in the sequence in microseconds. Used to determine the uncertainty in the 
+        boundaries of the pathay refocusing times.
+
     Returns
     -------
     experiment : ``ExperimentInfo`` object
@@ -687,5 +712,5 @@ def ex_ridme(tau1, tau2, pathways=None):
         reftimes = [reftimes[pathway-1] for pathway in pathways]
         harmonics = [harmonics[pathway-1] for pathway in pathways] 
 
-    return ExperimentInfo('RIDME',reftimes,harmonics)
+    return ExperimentInfo('RIDME',reftimes,harmonics,pulselength)
 #===============================================================================

--- a/docsrc/source/dipolar_guide_modelling.rst
+++ b/docsrc/source/dipolar_guide_modelling.rst
@@ -44,14 +44,15 @@ Using experimental pulse delays
 
 The dipolar pathways of a newly constructed dipolar model are initialized at arbitrary refocusing times and fully unconstrained. The refocusing times can be strongly constrained by knowing the experimental pulse sequence delays used to acquire the data. If the experiment used to acquire the data is known, as well as its pulse delays, then it is strongly recommended do so. 
  
-DeerLab provides a selection of experimental information generators for some of the most widely employed experimental methods (see the of :ref:`list of available experiments <modelsref_ex>`). These are functions that take the pulse sequence delays, and return an ``ExperimentInfo`` object. This can be passed to the ``dipolarmodel`` function via the ``experiment`` keyword argument, to incorporate the experiment information on the model and constrain some of its parameters. 
+DeerLab provides a selection of experimental information generators for some of the most widely employed experimental methods (see the of :ref:`list of available experiments <modelsref_ex>`). These are functions that take the pulse sequence delays, and return an ``ExperimentInfo`` object. This can be passed to the ``dipolarmodel`` function via the ``experiment`` keyword argument, to incorporate the experiment information on the model and constrain some of its parameters. These experimental information generators can also take information on the duration of the longest microwave pulses to more accurately constraint the parameters when using long pulses such as in frequency-swept or shaped microwave pulses.
 
-When using experimental time delays and the ``experiment`` argument, the model assumes that the experimental time axis ``t`` has its zero time at the beginning of the interpulse delay (see the illustrations of the individual experiment models for details). However, experimentally it is common not to record the first few hundred nanoseconds of signal. This results in a so-called deadtime, which many commercial spectrometers (such as Bruker) do not account for when storing the time-vector. It is very important to account for that deadtime in the model via :: 
+When using experimental time delays and the ``experiment`` argument, the model assumes that the experimental time axis ``t`` has its zero time at the beginning of the interpulse delay (see the illustrations of the individual experiment models for details). However, experimentally it is common not to record the first few hundred nanoseconds of signal. This results in a so-called start time (often also referred to as a deadtime), which many commercial spectrometers (such as Bruker) do not account for when storing the time-vector. It is very important to account for that time shift in the model via :: 
 
-    deadtime = 0.4 # Experimental deadtime of 400ns, in μs
-    t = t - deadtime # Shift the time axis to account for the deadtime 
+    t0 = 0.4   # Experimental start time of 400ns, in μs
+    t = t - t0 # Shift the time axis to account for the start time 
 
-If the time vector ``t`` does not have any deadtime, this step can be skipped. Otherwise, an incorrectly defined time vector will results in wrong results.
+If the time vector ``t`` does not have any time shift, this step can be skipped. Otherwise, an incorrectly defined time vector will results in wrong results.
+ 
 
 Constructing the dipolar model 
 *******************************

--- a/test/test_dipolarmodel.py
+++ b/test/test_dipolarmodel.py
@@ -314,6 +314,17 @@ def test_ex_4pdeer_fit():
 # ======================================================================
 
 # ======================================================================
+def test_ex_4pdeer_pulselength(): 
+    "Check the 4-pulse DEER experimental model."
+
+    pulselength = 0.1
+    experiment = ex_4pdeer(tau1,tau2, pathways=[1], pulselength=pulselength)
+    Vmodel = dipolarmodel(tdeer,r,Bmodel=bg_hom3d,experiment=experiment)
+
+    assert np.isclose(Vmodel.reftime.ub - Vmodel.reftime.lb,6*pulselength)
+# ======================================================================
+
+# ======================================================================
 def test_ex_rev5pdeer_type(): 
     "Check the reverse 5-pulse DEER experimental model."
 
@@ -333,6 +344,16 @@ def test_ex_rev5pdeer_fit():
     assert np.allclose(Vrev5pdeer,result.model,atol=1e-2) and ovl(result.P/1e5,Pr)>0.975
 # ======================================================================
 
+# ======================================================================
+def test_ex_rev5pdeer_pulselength(): 
+    "Check the 5-pulse DEER experimental model."
+
+    pulselength = 0.1
+    experiment = ex_rev5pdeer(tau1,tau2,tau3, pathways=[1], pulselength=pulselength)
+    Vmodel = dipolarmodel(tdeer,r,Bmodel=bg_hom3d,experiment=experiment)
+
+    assert np.isclose(Vmodel.reftime.ub - Vmodel.reftime.lb,6*pulselength)
+# ======================================================================
 
 # ======================================================================
 def test_ex_fwd5pdeer_type(): 
@@ -352,6 +373,17 @@ def test_ex_fwd5pdeer_fit():
     result = fit(Vmodel,Vfwd5pdeer,ftol=1e-4)
 
     assert np.allclose(Vfwd5pdeer,result.model,atol=1e-2) and ovl(result.P/1e5,Pr)>0.975
+# ======================================================================
+
+# ======================================================================
+def test_ex_fwd5pdeer_pulselength(): 
+    "Check the forward 5-pulse DEER experimental model."
+
+    pulselength = 0.1
+    experiment = ex_fwd5pdeer(tau1,tau2,tau3, pathways=[1], pulselength=pulselength)
+    Vmodel = dipolarmodel(tdeer,r,Bmodel=bg_hom3d,experiment=experiment)
+
+    assert np.isclose(Vmodel.reftime.ub - Vmodel.reftime.lb,6*pulselength)
 # ======================================================================
 
 # ======================================================================
@@ -375,6 +407,17 @@ def test_ex_sifter_fit():
 # ======================================================================
 
 # ======================================================================
+def test_ex_sifter_pulselength(): 
+    "Check the SIFTER experimental model."
+
+    pulselength = 0.1
+    experiment = ex_sifter(tau1,tau2,pathways=[1], pulselength=pulselength)
+    Vmodel = dipolarmodel(tdeer,r,Bmodel=bg_hom3d,experiment=experiment)
+
+    assert np.isclose(Vmodel.reftime.ub - Vmodel.reftime.lb,6*pulselength)
+# ======================================================================
+
+# ======================================================================
 def test_ex_ridme_type(): 
     "Check the RIDME experimental model."
 
@@ -392,6 +435,17 @@ def test_ex_ridme_fit():
     result = fit(Vmodel,Vridme,ftol=1e-4)
 
     assert np.allclose(Vridme,result.model,atol=1e-2) and ovl(result.P/1e5,Pr)>0.975
+# ======================================================================
+
+# ======================================================================
+def test_ex_ridme_pulselength(): 
+    "Check the RIDME experimental model."
+
+    pulselength = 0.1
+    experiment = ex_ridme(tau1,tau2,pathways=[1], pulselength=pulselength)
+    Vmodel = dipolarmodel(tdeer,r,Bmodel=bg_hom3d,experiment=experiment)
+
+    assert np.isclose(Vmodel.reftime.ub - Vmodel.reftime.lb,6*pulselength)
 # ======================================================================
 
 # ======================================================================


### PR DESCRIPTION
Add a new feature to the ``ex``-models such as ``ex_4pdeer`` to specify the duration of the longest microwave pulse in the pulse sequence. This allows more accurate automatic constraints of the refocusing times in the model, particularly when using long pulses (typically encountered when using shaped or frequency-swept pulses). 

For example:
```python
# 4-pulse DEER experiment using 16ns rectangular pulses
experimentInfo = dl.ex_4pdeer(tau1,tau2, pathways=[1,2,3], pulselength=0.016)
# 4-pulse DEER experiment using 100ns chirp pulses
experimentInfo = dl.ex_4pdeer(tau1,tau2, pathways=[1,2,3], pulselength=0.100)
```

Closes #362 