### PR TITLE
Add start values and frozen values to the printed parameter table

### DIFF
--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -620,17 +620,18 @@ class Model():
     """)
         string += '\n'
         table = []
-        table.append(['Name','Lower','Upper','Type','Frozen','Unit','Description'])  
-        alignment = ['<','^','^','^','^','^','<']
+        table.append(['Name','Lower','Start','Upper','Type','Frozen','Unit','Description'])  
+        alignment = ['<','^','^','^','^','^','^','<']
         for n,paramname in enumerate(self._parameter_list(order='vector')): 
             param_str = paramname
             lb_str = f'{np.atleast_1d(getattr(self,paramname).lb)[0]:5.3g}'
             ub_str = f'{np.atleast_1d(getattr(self,paramname).ub)[0]:5.3g}'
+            par0_str = f'{np.atleast_1d(getattr(self,paramname).par0)[0]:5.3g}' if np.atleast_1d(getattr(self,paramname).par0)[0] is not None else "-"
             linear_str = "linear" if np.all(getattr(self,paramname).linear) else "nonlin"
-            frozen_str = "Yes" if np.all(getattr(self,paramname).frozen) else "No"
+            frozen_str = f'{np.atleast_1d(getattr(self,paramname).value)[0]:5.3g}' if np.all(getattr(self,paramname).frozen) else "No"
             unit_str = str(getattr(self,paramname).unit)
             desc_str = str(getattr(self,paramname).description)
-            table.append([param_str,lb_str,ub_str,linear_str,frozen_str,unit_str,desc_str])
+            table.append([param_str,lb_str,par0_str,ub_str,linear_str,frozen_str,unit_str,desc_str])
         string += formatted_table(table,alignment)
         return string
     #---------------------------------------------------------------------------------------

--- a/docsrc/source/basics.rst
+++ b/docsrc/source/basics.rst
@@ -34,12 +34,12 @@ Parametric distance distributions
                 Signature: (r, mean, std)
                 Constants: [r]
                 Parameter Table: 
-                ======= ======= ======= ======== ======== ======= ==================== 
-                Name    Lower   Upper    Type    Frozen   Units   Description         
-                ======= ======= ======= ======== ======== ======= ==================== 
-                mean        1      20   nonlin     No      nm     Mean                
-                std      0.05     2.5   nonlin     No      nm     Standard deviation  
-                ======= ======= ======= ======== ======== ======= ==================== 
+                ====== ======= ======= ======= ======== ======== ====== ==================== 
+                Name   Lower   Start   Upper    Type    Frozen   Unit   Description         
+                ====== ======= ======= ======= ======== ======== ====== ==================== 
+                mean       1     3.5      20   nonlin     No      nm    Mean                
+                std     0.05     0.2     2.5   nonlin     No      nm    Standard deviation  
+                ====== ======= ======= ======= ======== ======== ====== ==================== 
 
                 
 In least-squares fitting, non-parametric distance distributions make fewer assumptions about the distribution than parametric distance distributions. They are more flexible and introduce less bias.
@@ -57,12 +57,12 @@ In DeerLab, all inter-molecular contributions to the dipolar modulation (i.e. th
         Signature: (t, conc, lam)
         Constants: [t]
         Parameter Table: 
-        ====== ======= ======= ======== ======== ======= ==================== 
-         Name   Lower   Upper    Type    Frozen   Units   Description         
-        ====== ======= ======= ======== ======== ======= ==================== 
-         conc    0.01   5e+03   nonlin     No      μM     Spin concentration  
-         lam        0       1   nonlin     No             Pathway amplitude   
-        ====== ======= ======= ======== ======== ======= ==================== 
+        ====== ======= ======= ======= ======== ======== ====== ==================== 
+        Name   Lower   Start   Upper    Type    Frozen   Unit   Description         
+        ====== ======= ======= ======= ======== ======== ====== ==================== 
+        conc    0.01      50   5e+03   nonlin     No      μM    Spin concentration  
+        lam        0       1       1   nonlin     No            Pathway amplitude   
+        ====== ======= ======= ======= ======== ======== ====== ==================== 
 
 
 DeerLab's :ref:`background models<modelsref_bg>` fall into two categories, physical and phenomenological: 

--- a/docsrc/source/dipolar_guide_modelling.rst
+++ b/docsrc/source/dipolar_guide_modelling.rst
@@ -88,14 +88,14 @@ A full summary of the constructed model(s) can be inspected by printing the mode
     Signature: (mod, reftime, conc, P)
     Constants: []
     Parameter Table: 
-    ========= ======= ======= ======== ======== ======= ====================================== 
-     Name      Lower   Upper    Type    Frozen   Units   Description                           
-    ========= ======= ======= ======== ======== ======= ====================================== 
-     mod           0       1   nonlin     No             Modulation depth                      
-     reftime     0.4     0.6   nonlin     No      μs     Refocusing time                       
-     conc       0.01   5e+03   nonlin     No      μM     Spin concentration                    
-     P             0     inf   linear     No     None    Non-parametric distance distribution  
-    ========= ======= ======= ======== ======== ======= ====================================== 
+    ========= ======= ======= ======= ======== ======== ====== ====================================== 
+    Name      Lower   Start   Upper    Type    Frozen   Unit   Description                           
+    ========= ======= ======= ======= ======== ======== ====== ====================================== 
+    mod           0    0.01       1   nonlin     No            Modulation depth                      
+    reftime    -inf       0     inf   nonlin     No      μs    Refocusing time                       
+    conc       0.01      50   5e+03   nonlin     No      μM    Spin concentration                    
+    P             0       0     inf   linear     No     nm⁻¹   Non-parametric distance distribution  
+    ========= ======= ======= ======= ======== ======== ====== ====================================== 
 
 
 From this point on, the model can be modified, manipulated and expanded freely as any other DeerLab model. Check out the :ref:`modelling guide <modelling_guide>` for more details and instructions on model manipulation.

--- a/docsrc/source/modelling_guide.rst
+++ b/docsrc/source/modelling_guide.rst
@@ -60,12 +60,12 @@ A summary of the model and all its parameters and related attributes can be quic
     Signature: (r, mean, std)
     Constants: [r]
     Parameter Table: 
-    ======= ======= ======= ======== ======== ======= ==================== 
-     Name    Lower   Upper    Type    Frozen   Units   Description         
-    ======= ======= ======= ======== ======== ======= ==================== 
-     mean        1      20   nonlin     No      nm     Mean                
-     std      0.05     2.5   nonlin     No      nm     Standard deviation  
-    ======= ======= ======= ======== ======== ======= ==================== 
+    ====== ======= ======= ======= ======== ======== ====== ==================== 
+    Name   Lower   Start   Upper    Type    Frozen   Unit   Description         
+    ====== ======= ======= ======= ======== ======== ====== ==================== 
+    mean       1     3.5      20   nonlin     No      nm    Mean                
+    std     0.05     0.2     2.5   nonlin     No      nm    Standard deviation  
+    ====== ======= ======= ======= ======== ======== ====== ====================
 
 .. _modelling_modifying_parameters:
 
@@ -156,12 +156,12 @@ To control that the model has been properly constructed, we can print the model 
     Signature: (center, std)
     Constants: []
     Parameter Table: 
-    ======== ======= ======= ======== ======== ======= ============= 
-     Name     Lower   Upper    Type    Frozen   Units   Description  
-    ======== ======= ======= ======== ======== ======= ============= 
-     center    -inf     inf   nonlin     No     None    None         
-     std       -inf     inf   nonlin     No     None    None         
-    ======== ======= ======= ======== ======== ======= ============= 
+    ======== ======= ======= ======= ======== ======== ====== ============= 
+    Name     Lower   Start   Upper    Type    Frozen   Unit   Description  
+    ======== ======= ======= ======= ======== ======== ====== ============= 
+    center    -inf     -       inf   nonlin     No     None   None         
+    std       -inf     -       inf   nonlin     No     None   None         
+    ======== ======= ======= ======= ======== ======== ====== ============= 
 
 We can see that the model has properly introduced the two non-linear parameters ``center`` and ``std``. By default, all new parameters are initialized unbounded (i.e. ``lb=-np.inf`` and  ``ub=+np.inf``). Any attributes can be changed freely after the model has been generated. For example ::
 
@@ -224,7 +224,7 @@ Therefore, we could define the following function: ::
     def bigaussian_fcn(center1,std1,center2,std2):
         gauss1 = np.exp(-(x-center1)**2/(2*std1**2)) # First Gaussian component
         gauss2 = np.exp(-(x-center2)**2/(2*std2**2)) # Second Gaussian component
-        Anonlin = np.vstack([y1,y2]) # Stack them vertically into a matrix
+        Anonlin = np.vstack([gauss1,gauss2]) # Stack them vertically into a matrix
         return Anonlin
     # Construct the model
     bigauss = dl.Model(bigaussian_fcn)
@@ -239,16 +239,16 @@ As before, we can check the state of the model by printing the ``mymodel`` objec
     Signature: (center1, std1, center2, std2, weight1, weight2)
     Constants: []
     Parameter Table: 
-    ========= ======= ======= ======== ======== ======= ============= 
-     Name      Lower   Upper    Type    Frozen   Units   Description  
-    ========= ======= ======= ======== ======== ======= ============= 
-     center1    -inf     inf   nonlin     No     None    None         
-     std1       -inf     inf   nonlin     No     None    None         
-     center2    -inf     inf   nonlin     No     None    None         
-     std2       -inf     inf   nonlin     No     None    None         
-     weight1       0     inf   linear     No     None    None         
-     weight2       0     inf   linear     No     None    None         
-    ========= ======= ======= ======== ======== ======= ============= 
+    ========= ======= ======= ======= ======== ======== ====== ============= 
+    Name      Lower   Start   Upper    Type    Frozen   Unit   Description  
+    ========= ======= ======= ======= ======== ======== ====== ============= 
+    center1    -inf     -       inf   nonlin     No     None   None         
+    std1       -inf     -       inf   nonlin     No     None   None         
+    center2    -inf     -       inf   nonlin     No     None   None         
+    std2       -inf     -       inf   nonlin     No     None   None         
+    weight1       0     -       inf   linear     No     None   None         
+    weight2       0     -       inf   linear     No     None   None         
+    ========= ======= ======= ======= ======== ======== ====== =============  
 
 We can see that the model has been correctly built, with four non-linear parameters (``center1``, ``center2``, ``std1``, and ``std2``) 
 and with two linear parameters (``weight1`` and ``weight2``), as indicated by the ``Type`` column. We can check whether a parameter is linear or non-linear by accessing its ``linear`` attribute, e.g.  :: 
@@ -317,12 +317,12 @@ By printing the model, we can check that the model has only two parameters: ::
     Signature: (sigma, dist)
     Constants: []
     Parameter Table: 
-    ======= ======= ======= ======== ======== ======= ============= 
-     Name    Lower   Upper    Type    Frozen   Units   Description  
-    ======= ======= ======= ======== ======== ======= ============= 
-     sigma    -inf     inf   nonlin     No     None    None         
-     dist        0     inf   linear     No     None    None         
-    ======= ======= ======= ======== ======== ======= ============= 
+    ======= ======= ======= ======= ======== ======== ====== ============= 
+    Name    Lower   Start   Upper    Type    Frozen   Unit   Description  
+    ======= ======= ======= ======= ======== ======== ====== ============= 
+    sigma    -inf     -       inf   nonlin     No     None   None         
+    dist        0     -       inf   linear     No     None   None         
+    ======= ======= ======= ======= ======== ======== ====== =============  
 
 
 
@@ -385,12 +385,12 @@ Let us print the model to examine the resulting model: ::
     Signature: (x, center, std)
     Constants: [x]
     Parameter Table: 
-    ======== ======= ======= ======== ======== ======= ============= 
-     Name     Lower   Upper    Type    Frozen   Units   Description  
-    ======== ======= ======= ======== ======== ======= ============= 
-     center    -inf     inf   nonlin     No     None    None         
-     std       -inf     inf   nonlin     No     None    None         
-    ======== ======= ======= ======== ======== ======= ============= 
+    ======== ======= ======= ======= ======== ======== ====== ============= 
+    Name     Lower   Start   Upper    Type    Frozen   Unit   Description  
+    ======== ======= ======= ======= ======== ======== ====== ============= 
+    center    -inf     -       inf   nonlin     No     None   None         
+    std       -inf     -       inf   nonlin     No     None   None         
+    ======== ======= ======= ======= ======== ======== ====== ============= 
 
 We can see that the model has only the two non-linear parameters as expected, and under ``Constants`` we can see that ``x`` has been adequately defined. From the ``Signature`` we can also check that the ``x`` constant can be passed to evaluate the model. 
 
@@ -407,12 +407,12 @@ All ``Model`` objects can be called as normal functions by specifying the parame
     Signature: (x, center, std)
     Constants: [x]
     Parameter Table: 
-    ======== ======= ======= ======== ======== ======= ============= 
-     Name     Lower   Upper    Type    Frozen   Units   Description  
-    ======== ======= ======= ======== ======== ======= ============= 
-     center    -inf     inf   nonlin     No     None    None         
-     std       -inf     inf   nonlin     No     None    None         
-    ======== ======= ======= ======== ======== ======= ============= 
+    ======== ======= ======= ======= ======== ======== ====== ============= 
+    Name     Lower   Start   Upper    Type    Frozen   Unit   Description  
+    ======== ======= ======= ======= ======== ======== ====== ============= 
+    center    -inf     -       inf   nonlin     No     None   None         
+    std       -inf     -       inf   nonlin     No     None   None         
+    ======== ======= ======= ======= ======== ======== ====== ============= 
 
 In the model printout, under ``Signature`` the exact signature of the model is given. The order and names of the arguments are as shown there.
 
@@ -504,16 +504,16 @@ As always, we can check the results of the operation by printing the model for a
     Signature: (center_1, width_1, center_2, width_2, scale_1, scale_2)
     Constants: []
     Parameter Table: 
-    ========== ======= ======= ======== ======== ======= ============= 
-     Name       Lower   Upper    Type    Frozen   Units   Description  
-    ========== ======= ======= ======== ======== ======= ============= 
-     center_1    -inf     inf   nonlin     No     None    None         
-     width_1     -inf     inf   nonlin     No     None    None         
-     center_2    -inf     inf   nonlin     No     None    None         
-     width_2     -inf     inf   nonlin     No     None    None         
-     scale_1        0     inf   linear     No     None    None         
-     scale_2        0     inf   linear     No     None    None         
-    ========== ======= ======= ======== ======== ======= ============= 
+    ========== ======= ======= ======= ======== ======== ====== ================ 
+    Name       Lower   Start   Upper    Type    Frozen   Unit   Description     
+    ========== ======= ======= ======= ======== ======== ====== ================ 
+    center_1    -inf     -       inf   nonlin     No     None   None            
+    std_1       -inf     -       inf   nonlin     No     None   None            
+    center_2    -inf     -       inf   nonlin     No     None   None            
+    std_2       -inf     -       inf   nonlin     No     None   None            
+    scale_1        0       1     inf   linear     No     None   Scaling factor  
+    scale_2        0       1     inf   linear     No     None   Scaling factor  
+    ========== ======= ======= ======= ======== ======== ====== ================ 
 
 
 We can see that the merge has been successful. The model now takes the parameters of both ``gauss`` models, and their names have been adapted with the respective suffixes as described above. Now we can call the ``mergemodel`` to get both Gaussians responses, both centered equally, but the second being twice as broad as the first one: ::
@@ -574,16 +574,16 @@ As always, we can check the results of the operation by printing the model for a
     Signature: (center_1, width_1, center_2, width_2, scale_1, scale_2)
     Constants: []
     Parameter Table: 
-    ========== ======= ======= ======== ======== ======= ============= 
-     Name       Lower   Upper    Type    Frozen   Units   Description  
-    ========== ======= ======= ======== ======== ======= ============= 
-     center_1    -inf     inf   nonlin     No     None    None         
-     width_1     -inf     inf   nonlin     No     None    None         
-     center_2    -inf     inf   nonlin     No     None    None         
-     width_2     -inf     inf   nonlin     No     None    None         
-     scale_1        0     inf   linear     No     None    None         
-     scale_2        0     inf   linear     No     None    None         
-    ========== ======= ======= ======== ======== ======= ============= 
+    ========== ======= ======= ======= ======== ======== ====== ================ 
+    Name       Lower   Start   Upper    Type    Frozen   Unit   Description     
+    ========== ======= ======= ======= ======== ======== ====== ================ 
+    center_1    -inf     -       inf   nonlin     No     None   None            
+    std_1       -inf     -       inf   nonlin     No     None   None            
+    center_2    -inf     -       inf   nonlin     No     None   None            
+    std_2       -inf     -       inf   nonlin     No     None   None            
+    scale_1        0       1     inf   linear     No     None   Scaling factor  
+    scale_2        0       1     inf   linear     No     None   Scaling factor  
+    ========== ======= ======= ======= ======== ======== ====== ================ 
 
 We can see that the merge has been successful. The model now takes the parameters of both ``gauss`` models, and their names have been adapted with the respective suffixes described above—the newly introduced linear parameters ``scale_1`` and ``scale_2`` work as linear combination weights. 
 
@@ -610,16 +610,16 @@ and we can check the resulting model ::
     Signature: (sigma_1, weight_1, sigma_2, weight_2, dist_1, dist_2)
     Constants: []
     Parameter Table: 
-    ========== ======= ======= ======== ======== ======= ================== 
-     Name       Lower   Upper    Type    Frozen   Units   Description       
-    ========== ======= ======= ======== ======== ======= ================== 
-     sigma_1     -inf     inf   nonlin     No     None    None              
-     weight_1       0     inf   nonlin     No     None    Weighting factor  
-     sigma_2     -inf     inf   nonlin     No     None    None              
-     weight_2       0     inf   nonlin     No     None    Weighting factor  
-     dist_1         0     inf   linear     No     None    None              
-     dist_2         0     inf   linear     No     None    None              
-    ========== ======= ======= ======== ======== ======= ================== 
+    ========== ======= ======= ======= ======== ======== ====== ================== 
+    Name       Lower   Start   Upper    Type    Frozen   Unit   Description       
+    ========== ======= ======= ======= ======== ======== ====== ================== 
+    sigma_1     -inf     -       inf   nonlin     No     None   None              
+    weight_1       0       1     inf   nonlin     No     None   Weighting factor  
+    sigma_2     -inf     -       inf   nonlin     No     None   None              
+    weight_2       0       1     inf   nonlin     No     None   Weighting factor  
+    scale_1        0       1     inf   linear     No     None   Scaling factor    
+    scale_2        0       1     inf   linear     No     None   Scaling factor    
+    ========== ======= ======= ======= ======== ======== ====== ================== 
 
 
 The linearly combined model has been successfully constructed, and the non-linear weighting parameters ``weight_1`` and ``weight_2`` have also been included in the model as requested. 
@@ -659,15 +659,15 @@ and check the model by printing it ::
     Signature: (center1, std, center2, weight1, weight2)
     Constants: []
     Parameter Table: 
-    ========= ======= ======= ======== ======== ======= ============= 
-     Name      Lower   Upper    Type    Frozen   Units   Description  
-    ========= ======= ======= ======== ======== ======= ============= 
-     center1    -inf     inf   nonlin     No     None    None         
-     std        -inf     inf   nonlin     No     None    None         
-     center2    -inf     inf   nonlin     No     None    None         
-     weight1       0     inf   linear     No     None    None         
-     weight2       0     inf   linear     No     None    None         
-    ========= ======= ======= ======== ======== ======= ============= 
+    ========= ======= ======= ======= ======== ======== ====== ============= 
+    Name      Lower   Start   Upper    Type    Frozen   Unit   Description  
+    ========= ======= ======= ======= ======== ======== ====== ============= 
+    center1    -inf     -       inf   nonlin     No     None   None         
+    std        -inf     -       inf   nonlin     No     None   None         
+    center2    -inf     -       inf   nonlin     No     None   None         
+    weight1       0     -       inf   linear     No     None   None         
+    weight2       0     -       inf   linear     No     None   None         
+    ========= ======= ======= ======= ======== ======== ====== ============= 
 
 
 The model now has the new ``std`` parameter instead of the ``std1`` and ``std2`` parameters. The linkage can be checked by comparing the two models ::
@@ -725,15 +725,15 @@ and check the model by printing it ::
     Signature: (center1, std1, center2, weight1, weight2)
     Constants: []
     Parameter Table: 
-    ========= ======= ======= ======== ======== ======= ============= 
-     Name      Lower   Upper    Type    Frozen   Units   Description  
-    ========= ======= ======= ======== ======== ======= ============= 
-     center1    -inf     inf   nonlin     No     None    None         
-     center2    -inf     inf   nonlin     No     None    None         
-     std2       -inf     inf   nonlin     No     None    None         
-     weight1       0     inf   linear     No     None    None         
-     weight2       0     inf   linear     No     None    None         
-    ========= ======= ======= ======== ======== ======= ============= 
+    ========= ======= ======= ======= ======== ======== ====== ============= 
+    Name      Lower   Start   Upper    Type    Frozen   Unit   Description  
+    ========= ======= ======= ======= ======== ======== ====== ============= 
+    center1    -inf     -       inf   nonlin     No     None   None         
+    center2    -inf     -       inf   nonlin     No     None   None         
+    std2       -inf     -       inf   nonlin     No     None   None         
+    weight1       0     -       inf   linear     No     None   None         
+    weight2       0     -       inf   linear     No     None   None         
+    ========= ======= ======= ======= ======== ======== ====== ============= 
 
 The ``std1`` parameter has been removed from the parameter list as it is now given twice the value of ``std2``.
 


### PR DESCRIPTION
MWE: 
```python
import deerlab as dl 
import numpy as np 
Pmodel = dl.dd_gauss
Pmodel.mean.freeze(4.5)

print(Pmodel)
```
Before: 
```
Description: Gaussian distribution model
Signature: (r, mean, std)
Constants: [r]
Parameter Table:
======= ======= ======= ======== ======== ======= ====================
 Name    Lower   Upper    Type    Frozen   Units   Description
======= ======= ======= ======== ======== ======= ====================
 mean        1      20   nonlin     No      nm     Mean
 std      0.05     2.5   nonlin     No      nm     Standard deviation
======= ======= ======= ======== ======== ======= ====================
```

Now: 
```
Description: Gaussian distribution model
Signature: (r, mean, std)
Constants: [r]
Parameter Table: 
====== ======= ======= ======= ======== ======== ====== ==================== 
 Name   Lower   Start   Upper    Type    Frozen   Unit   Description         
====== ======= ======= ======= ======== ======== ====== ==================== 
 mean       1     3.5      20   nonlin     4.5     nm    Mean                
 std     0.05     0.2     2.5   nonlin     No      nm    Standard deviation  
====== ======= ======= ======= ======== ======== ====== ==================== 
```