### PR TITLE
Freeze Sphinx-gallery version to 0.9.0 to fix current docs build

### DIFF
--- a/.github/workflows/deploy_ghpages.yml
+++ b/.github/workflows/deploy_ghpages.yml
@@ -28,7 +28,7 @@ jobs:
            python -m pip install --upgrade pip
            python -m pip install pydata-sphinx-theme==0.7.1
            python -m pip install numpydoc
-           python -m pip install sphinx-gallery
+           python -m pip install sphinx-gallery==0.9.0
            python -m pip install sphinxcontrib-httpdomain
            python -m pip install sphinxcontrib-ghcontributors
            python -m pip install sphinx-issues

--- a/.github/workflows/docs_PR.yml
+++ b/.github/workflows/docs_PR.yml
@@ -32,7 +32,7 @@ jobs:
            python -m pip install --upgrade pip
            python -m pip install pydata-sphinx-theme==0.7.1
            python -m pip install numpydoc
-           python -m pip install sphinx-gallery
+           python -m pip install sphinx-gallery==0.9.0
            python -m pip install sphinxcontrib-httpdomain
            python -m pip install sphinxcontrib-ghcontributors
            python -m pip install sphinx-copybutton  


### PR DESCRIPTION
In their latest versions, Sphinx-Gallery build the HTML using a CSS ``grid`` display of the gallery. This breaks our current build and leads to visuals errors and bugs. 

Fixing the version to 0.9.0 allows our documentation to build without issues.