### PR TITLE
Return uncertainties for normalization factors of normalized parameters

### DIFF
--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -1302,9 +1302,8 @@ def fit(model_, y, *constants, par0=None, penalties=None, bootstrap=0, noiselvl=
                     non_normalized = FitResult_param_[key] # Non-normalized value
                     FitResult_param_[key] = param.normalization(FitResult_param_[key]) # Normalized value
                     FitResult_param_[f'{key}_scale'] = np.mean(non_normalized/FitResult_param_[key]) # Normalization factor
-                    FitResult_param_[f'{key}_scale'] = np.mean(non_normalized/FitResult_param_[key]) # Normalization factor
+                    FitResult_paramuq_[f'{key}_scaleUncert'] = FitResult_paramuq_[f'{key}Uncert'].propagate(lambda x: np.mean(x/param.normalization(x)))
                     FitResult_paramuq_[f'{key}Uncert'] = FitResult_paramuq_[f'{key}Uncert'].propagate(lambda x: x/FitResult_param_[f'{key}_scale'], lb=param.lb, ub=param.ub) # Normalization of the uncertainty
-                    FitResult_paramuq_[f'{key}_scaleUncert'] = UQResult('void')
     if len(noiselvl)==1: 
         noiselvl = noiselvl[0]
 


### PR DESCRIPTION
Now the `fit` function returns a full uncertainty quantification for the normalization factor of normalized model parameters. 

For example here the `P_scale` output: 
```
Goodness-of-fit: 
========= ============= ============ ======= =========== 
 Dataset   Noise level   Reduced 𝛘2   RMSD       AIC
========= ============= ============ ======= ===========
   #1         0.009        1.290      0.010   -1688.358
========= ============= ============ ======= ===========
Model hyperparameters:
==========================
 Regularization parameter
==========================
          0.478
==========================
Model parameters:
=========== ======== ========================= ====== ======================================
 Parameter   Value    95%-Confidence interval   Unit   Description
=========== ======== ========================= ====== ======================================
 mod         0.400    (0.395,0.406)                    Modulation depth
 reftime     0.501    (0.498,0.504)              μs    Refocusing time
 conc        49.508   (45.267,53.749)            μM    Spin concentration
 P           ...      (...,...)                 nm⁻¹   Non-parametric distance distribution
 P_scale     1.001    (0.999,1.003)             None   Normalization factor of P
=========== ======== ========================= ====== ======================================
```