### PR TITLE
Implement faster NNLS solver based on the Goldfarb/Idnani dual algorithm

### DIFF
--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -1299,10 +1299,13 @@ def fit(model_, y, *constants, par0=None, penalties=None, bootstrap=0, noiselvl=
                 param.unfreeze() 
             if np.all(param.linear):
                 if param.normalization is not None:
-                    non_normalized = FitResult_param_[key] # Non-normalized value
+                    def _scale(x):
+                        x = x + np.finfo(float).eps
+                        return np.mean(x/param.normalization(x))
+                    FitResult_param_[f'{key}_scale'] = _scale(FitResult_param_[key]) # Normalization factor
                     FitResult_param_[key] = param.normalization(FitResult_param_[key]) # Normalized value
-                    FitResult_param_[f'{key}_scale'] = np.mean(non_normalized/FitResult_param_[key]) # Normalization factor
-                    FitResult_paramuq_[f'{key}_scaleUncert'] = FitResult_paramuq_[f'{key}Uncert'].propagate(lambda x: np.mean(x/param.normalization(x)))
+
+                    FitResult_paramuq_[f'{key}_scaleUncert'] = FitResult_paramuq_[f'{key}Uncert'].propagate(_scale)
                     FitResult_paramuq_[f'{key}Uncert'] = FitResult_paramuq_[f'{key}Uncert'].propagate(lambda x: x/FitResult_param_[f'{key}_scale'], lb=param.lb, ub=param.ub) # Normalization of the uncertainty
     if len(noiselvl)==1: 
         noiselvl = noiselvl[0]

--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -1096,10 +1096,11 @@ def fit(model_, y, *constants, par0=None, penalties=None, bootstrap=0, noiselvl=
     nnlsSolver : string, optional
         Solver used to solve a non-negative least-squares problem (if applicable):
 
-        * ``'cvx'`` - Optimization of the NNLS problem using the cvxopt package.
+        * ``'qp'`` - Optimization of the NNLS problem using the ``quadprog`` package.
+        * ``'cvx'`` - Optimization of the NNLS problem using the ``cvxopt`` package.
         * ``'fnnls'`` - Optimization using the fast NNLS algorithm.
         
-        The default is ``'cvx'``.
+        The default is ``'qp'``.
 
     verbose : scalar integer, optional
         Level of verbosity during the analysis:

--- a/docsrc/source/installation.rst
+++ b/docsrc/source/installation.rst
@@ -45,7 +45,7 @@ DeerLab installs the following packages:
 * `joblib <https://joblib.readthedocs.io/en/latest/>`_ - Library lightweight pipelining and parallelization.
 * `tqdm <https://github.com/tqdm/tqdm>`_ - A lightweight package for smart progress meters.
 * `dill <https://github.com/uqfoundation/dill>`_ - An extension of Python's pickle module for serializing and de-serializing python objects.
-
+* `quadprog <https://pypi.org/project/quadprog/>`_ - A quadratic programming solver
 Installing from Anaconda
 *************************
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
                         'memoization>=0.3.1',
                         'pytest>=6.2.2',
                         'setuptools>=53.0.0',
+                        'quadprog>=0.1.11',
                         ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/test/test_snlls.py
+++ b/test/test_snlls.py
@@ -457,7 +457,7 @@ def test_cost_value():
     # Separable LSQ fit
     fit = snlls(V,lambda lam: dipolarkernel(t,r,mod=lam),nlpar0,lb,ub,lbl,ubl)
 
-    assert isinstance(fit.cost,float) and np.round(fit.cost/np.sum(fit.residuals**2),5)==1
+    assert isinstance(fit.cost,float) and np.round(fit.cost/(np.sum(fit.residuals**2)/len(fit.residuals)),5)==1
 #============================================================
 
 def test_confinter_values():

--- a/test/test_snlls_nlls.py
+++ b/test/test_snlls_nlls.py
@@ -209,7 +209,7 @@ def test_cost_value():
     ub = [20, 1]
     model = lambda p: K@dd_gauss(r,*p)
     fit = snlls(V,model,par0,lb,ub)
-    assert isinstance(fit.cost,float) and np.round(fit.cost/np.sum(fit.residuals**2),5)==1
+    assert isinstance(fit.cost,float) and np.round(fit.cost/(np.sum(fit.residuals**2)/len(fit.residuals)),5)==1
 # ======================================================================
 
 def test_global_weights():

--- a/test/test_snlls_rlls.py
+++ b/test/test_snlls_rlls.py
@@ -254,7 +254,7 @@ def test_cost_value():
     V = K@P + whitegaussnoise(t,0.01)
     fit = snlls(V,K,lbl=np.zeros_like(r))
 
-    assert isinstance(fit.cost,float) and np.round(fit.cost/np.sum(fit.residuals**2),5)==1
+    assert isinstance(fit.cost,float) and np.round(fit.cost/(np.sum(fit.residuals**2)/len(fit.residuals)),5)==1
 #============================================================
 
 def test_convergence_criteria():


### PR DESCRIPTION
Implements a new NNLS solver function `qpnnls` that uses the Goldfarb/Idnani dual algorithm implemented in the `quadprog` package. The resulting NNLS solver is more efficient than the current implementation with `cvxopt` (see below for a benchmark example) without sacrificing any (noticeable) accuracy (I tested and benchmarked this to make sure). Since NNLS problem-solving is the bottleneck of most applications of DeerLab, it results in a significant improvement in speed when analyzing semi-parametric models. 

The following benchmarks the performance of DeerLab's `cvxnnls` and `qpnnls` functions when solving the NNLS problem of the dipolar model. The analysis is repeated with different `rmax` values of the distance vector with a fixed resolution of 0.05nm (an approximate lower bound of physically-meaningful resolution attainable), effectively increasing the number of linear parameters to estimate during the NNLS problem.
 
```python 
import numpy as np
import deerlab as dl 
import matplotlib.pyplot as plt 
from tqdm import tqdm 
from deerlab.solvers import cvxnnls, qpnnls
from timeit import timeit 

np.random.seed(42)
Nrs = np.arange(50,200,2)
cvx_times,qp_times,cvx_rmsd,qp_rmsd = [],[],[],[]
for nr in tqdm(Nrs):

    # Dipolar EPR NNLS problem
    dr = 0.05
    t = np.arange(-1,5,0.008)
    r = np.linspace(1.5,2+dr*nr,nr)
    A = dl.dipolarkernel(t,r)
    alpha=0.005
    L = dl.regoperator(r,2)
    xtruth = dl.dd_gauss(r,3,0.2)
    # Forward simulation
    y = A@xtruth + dl.whitegaussnoise(t,0.05)

    # Prepare NNLS problem
    AtAreg = A.T@A + alpha**2*L.T@L
    Aty = A.T@y
    N = len(r)
    
    # Solve NNLS problem
    fcn = lambda : qpnnls(AtAreg, Aty)
    duration = timeit(fcn, number=100)
    qp_times.append(duration)
    qp_rmsd.append(1/nr*np.linalg.norm(xtruth-fcn()))

    fcn = lambda: cvxnnls(AtAreg,Aty)
    duration = timeit(fcn, number=100)
    cvx_times.append(duration)
    cvx_rmsd.append(1/nr*np.linalg.norm(xtruth-fcn()))


rmax = 2+dr*Nrs
#plt.subplot(121)
plt.plot(rmax,cvx_times,label='CVX-NNLS')
plt.plot(rmax,qp_times,label='QP-NNLS')
plt.yscale('log')
plt.ylabel('Run time [s]')
plt.xlabel('rmax [nm]')
plt.legend(loc='best')
```

![Figure_1](https://user-images.githubusercontent.com/48292540/197790430-e9de233d-4c1b-4c7f-93ba-84a0035dbef7.png)

The results show that the `qpnnls` is significantly faster than `cvxopt` for most physically-meaningful cases here. If the distance range is significantly constrained (i.e. the number of linear parameter is small), the algorithm is orders of magnitude faster. 

Another indicator is the duration of the `pytest` run over the full test suite. It takes `pytest` approximately 232s using `cvxopt` and 125s using `qpnnls` showing a general doubling of the execution speed. For the `snlls` test we also observe the increase in performance:
| Test            | `cvxnnls` | `qpnnls` |
|-----------------|---------|--------|
| `test_snlls_rlls` | 32.49s   | 13.61s  |
| `test_snlls_nlls` | 4.20s   | 4.05s   |
| `test_snlls`      | 45.43s   | 16.23s  |

Due to the overall good performance of the `qpnnls` solver, the PR will set it as the default NNLS solver engine, whereas `cvxnnls` will remain accessible through the `nnlsSolver` option of `snlls`. 