### PR TITLE
`fit`: Remove the automatic computation of the `modelUncert` output

### DIFF
--- a/deerlab/model.py
+++ b/deerlab/model.py
@@ -1158,9 +1158,7 @@ def fit(model_, y, *constants, par0=None, penalties=None, bootstrap=0, noiselvl=
     paramUncert : :ref:`UQResult`
         Uncertainty quantification of the parameter vector ordered according to the model parameter indices.
     model : ndarray
-        Fitted model response.
-    modelUncert : :ref:`UQResult`
-        Uncertainty quantification of the fitted model response.        
+        Fitted model response.     
     regparam : scalar
         Regularization parameter value used for the regularization of the linear parameters.
     penweights : scalar or list thereof 
@@ -1308,10 +1306,8 @@ def fit(model_, y, *constants, par0=None, penalties=None, bootstrap=0, noiselvl=
         fitresults.param = fitresults.paramUncert.median
         # Get the uncertainty estimates for the model response
         fitresults.model = [param_uq[n].median for n in range(1,len(param_uq))]
-        fitresults.modelUncert = [param_uq[n] for n in range(1,len(param_uq))]
         if len(fitresults.model)==1: 
             fitresults.model = fitresults.model[0]
-            fitresults.modelUncert = fitresults.modelUncert[0]
     # Get some basic information on the parameter vector
     keys = model._parameter_list(order='vector')
 
@@ -1320,7 +1316,7 @@ def fit(model_, y, *constants, par0=None, penalties=None, bootstrap=0, noiselvl=
     # Dictionary of parameter names and fit uncertainties
     FitResult_paramuq = {f'{key}Uncert': model._getparamuq(fitresults.paramUncert,idx) for key,idx in zip(keys,param_idx)}
     # Dictionary of other fit quantities of interest
-    FitResult_dict = {key: getattr(fitresults,key) for key in ['param','paramUncert','model','modelUncert','cost','plot','residuals','stats','regparam']}
+    FitResult_dict = {key: getattr(fitresults,key) for key in ['param','paramUncert','model','cost','plot','residuals','stats','regparam']}
     _paramlist = model._parameter_list('vector')
 
     # Prepare the propagate() and evaluate() methods

--- a/deerlab/solvers.py
+++ b/deerlab/solvers.py
@@ -297,7 +297,7 @@ def _prepare_linear_lsq(A,lb,ub,reg,L,tol,maxiter,nnlsSolver):
 # ===========================================================================================
 
 # ===========================================================================================
-def _model_evaluation(ymodels,parfit,paruq,uq):
+def _model_evaluation(ymodels,parfit,paruq,uq,modeluq):
     """
     Model evaluation
     ================
@@ -308,7 +308,7 @@ def _model_evaluation(ymodels,parfit,paruq,uq):
     modelfit, modelfituq = [],[]
     for ymodel in ymodels: 
         modelfit.append(ymodel(parfit))
-        if uq: 
+        if uq and modeluq: 
             modelfituq.append(paruq.propagate(ymodel))
         else:
             modelfituq.append(UQResult('void'))
@@ -392,7 +392,7 @@ def _insertfrozen(parfit,parfrozen,frozen):
 def snlls(y, Amodel, par0=None, lb=None, ub=None, lbl=None, ubl=None, nnlsSolver='qp', reg='auto', weights=None, verbose=0,
           regparam='aic', regparamrange=None, multistart=1, regop=None, alphareopt=1e-3, extrapenalty=None, subsets=None,
           ftol=1e-8, xtol=1e-8, max_nfev=1e8, lin_tol=1e-15, lin_maxiter=1e4, noiselvl=None, lin_frozen=None, mask=None,
-          nonlin_frozen=None, uq=True):
+          nonlin_frozen=None, uq=True, modeluq=False):
     r""" Separable non-linear least squares (SNLLS) solver
 
     Fits a linear set of parameters `\theta_\mathrm{lin}` and non-linear parameters `\theta_\mathrm{nonlin}`
@@ -531,7 +531,10 @@ def snlls(y, Amodel, par0=None, lb=None, ub=None, lbl=None, ubl=None, nnlsSolver
         will be optimized, if set to a numerical value it will be fixed to it and ignored during the optimization.
 
     uq : boolean, optional
-        Enable/disable the uncertainty quantification analysis, by default it is enabled.
+        Enable/disable the uncertainty quantification analysis. Enabled by default.
+
+    modeluq : boolean, optional
+        Enable/disable the propagation of the parameter uncertainties to the model's response (can be computationally costly). Disabled by default
 
     subsets : array_like, optional 
         Vector of dataset subset indices, if the datasets are passed concatenated instead of a list.
@@ -561,7 +564,7 @@ def snlls(y, Amodel, par0=None, lb=None, ub=None, lbl=None, ubl=None, nnlsSolver
     paramUncert : :ref:`UQResult`
         Uncertainty quantification of the full parameter set.
     modelUncert : :ref:`UQResult`
-        Uncertainty quantification of the fitted model.
+        Uncertainty quantification of the fitted model. Only computed if ``modeluq=True``.
     regparam : scalar
         Regularization parameter value used for the regularization of the linear parameters.
     plot : callable
@@ -951,7 +954,7 @@ def snlls(y, Amodel, par0=None, lb=None, ub=None, lbl=None, ubl=None, nnlsSolver
         def ymodel(n):
             return lambda p: ymodel_(n)(p) + 1j*(Amodel(p[nonlin_idx])@p[lin_idx])[imagsubsets[n]]
     ymodels = [ymodel(n) for n in range(len(subsets))]
-    modelfit,modelfituq = _model_evaluation(ymodels,parfit,paramuq,uq)
+    modelfit,modelfituq = _model_evaluation(ymodels,parfit,paramuq,uq,modeluq)
 
     # Make lists of data and fits
     ys = [y[subset] for subset in subsets]

--- a/docsrc/source/fitting_guide.rst
+++ b/docsrc/source/fitting_guide.rst
@@ -236,8 +236,6 @@ Estimated parameter uncertainty (``FitResult.<param>Uncert``)
     The ``FitResult`` will contain an attribute ``<param>Uncert`` of the same name as each parameter in the model. This will contain the full uncertainty estimate of the parameter in the form of an ``UQResult`` object (see here for details).  
 Estimated model response (``FitResult.model``)
     It is the maximum likelihood estimate of the model's response. It can be computed as well from the model and the fitted parameter values. 
-Estimated model response (``FitResult.modelUncert``)
-    The uncertainty estimate of the model's response in the form of an ``UQResult`` object propagated from the uncertainty on the parameters.  
 Statistical descriptors (``FitResult.stats``)    
     A dictionary of statistical quantities such as reduced chi-square, RMSD or AIC values quantifying the goodness-of-fit and model complexity. The reduced chi-square statistic ``FitResult.stats['chi2red']`` allows the assessment of whether the fit describes the data or not. A comparable value to 1 will indicate a good fit of the input data. The AIC ``FitResult.stats['aic']`` and other information-based quantities allow the comparison between fits based on alternate models and selecting the most appropriate model. 
 Penalty and regularization weights (``FitResult.regparam`` and ``FitResult.penweights``)

--- a/docsrc/source/uncertainty_guide.rst
+++ b/docsrc/source/uncertainty_guide.rst
@@ -109,7 +109,8 @@ Confidence intervals
     For vector quantities, confidence intervals are always returned as a ``Nx2``-array, where each of the ``N`` elements of the vector has two values, the lower and upper boundaries of the confidence interval. ::
 
         # Get the confidence intervals on the model response vector
-        response_ci = fitresult.modelUncert.ci(95)
+        model_uq = fitresult.propagate(model)
+        response_ci = model_uq.ci(95)
 
         response_ci[:,0] # lower bound of the 95%-CI of the distance distribution
         response_ci[:,1] # upper bound of the 95%-CI of the distance distribution
@@ -119,4 +120,4 @@ Uncertainty distributions
     A complete description of the uncertainty is the uncertainty distributions for the fit parameter. These can be requested from the ``pardist`` method. Using ``pardist(n)`` will return the uncertainty probability density function and its abscissa values for the corresponding quantity's ``n``-th element. For example, ::
 
         pardist = fitresult.<parameter>Uncert.pardist(0) # Get the parameter uncertainty distribution
-        modeldist5 = fitresult.modelUncert.pardist(4) # Get the uncertainty distribution of the model's response 5th element
+        modeldist5 = model_uq.pardist(4) # Get the uncertainty distribution of the model's response 5th element

--- a/examples/advanced/ex_extracting_gauss_constraints.py
+++ b/examples/advanced/ex_extracting_gauss_constraints.py
@@ -57,8 +57,9 @@ results = dl.fit(Pmodel,Pfit,r)
 
 # Extract the fit results
 PGauss = results.model
-PGauss_ci50 = results.modelUncert.ci(50)
-PGauss_ci95 = results.modelUncert.ci(95)
+PGauss_uq = results.propagate(Pmodel,r,lb=np.zeros_like(r))
+PGauss_ci50 = PGauss_uq.ci(50)
+PGauss_ci95 = PGauss_uq.ci(95)
 
 # Print the parameters nicely
 print(f'Gaussian components with (95%-confidence intervals):')

--- a/examples/basic/ex_bootstrapping.py
+++ b/examples/basic/ex_bootstrapping.py
@@ -58,7 +58,7 @@ print(results)
 
 # Extract fitted dipolar signal
 Vfit = results.model
-Vci = results.modelUncert.ci(95)
+Vci = results.propagate(Vmodel).ci(95)
 
 # Extract fitted distance distribution
 Pfit = results.P

--- a/examples/basic/ex_compactness_with_without.py
+++ b/examples/basic/ex_compactness_with_without.py
@@ -61,7 +61,7 @@ for n,results in enumerate([results_with, results_without]):
 
     # Extract fitted dipolar signal
     Vfit = results.model
-    Vci = results.modelUncert.ci(95)
+    Vci = results.propagate(Vmodel).ci(95)
 
     # Extract fitted distance distribution
     Pfit = results.P

--- a/examples/basic/ex_fitting_4pdeer.py
+++ b/examples/basic/ex_fitting_4pdeer.py
@@ -47,7 +47,7 @@ print(results)
 
 # Extract fitted dipolar signal
 Vfit = results.model
-Vci = results.modelUncert.ci(95)
+Vci = results.propagate(Vmodel).ci(95)
 
 # Extract fitted distance distribution
 Pfit = results.P

--- a/examples/basic/ex_fitting_4pdeer_compactness.py
+++ b/examples/basic/ex_fitting_4pdeer_compactness.py
@@ -50,7 +50,7 @@ print(results)
 
 # Extract fitted dipolar signal
 Vfit = results.model
-Vci = results.modelUncert.ci(95)
+Vci = results.propagate(Vmodel).ci(95)
 
 # Extract fitted distance distribution
 Pfit = results.P

--- a/examples/basic/ex_fitting_4pdeer_gauss.py
+++ b/examples/basic/ex_fitting_4pdeer_gauss.py
@@ -48,7 +48,7 @@ print(results)
 
 # Extract fitted dipolar signal
 Vfit = results.model
-Vci = results.modelUncert.ci(95)
+Vci = results.propagate(Vmodel).ci(95)
 
 # Extract fitted distance distribution
 Pfit = results.evaluate(Pmodel,r)

--- a/examples/basic/ex_fitting_4pdeer_pathways.py
+++ b/examples/basic/ex_fitting_4pdeer_pathways.py
@@ -47,7 +47,7 @@ print(results)
 
 # Extract fitted dipolar signal
 Vfit = results.model
-Vci = results.modelUncert.ci(95)
+Vci = results.propagate(Vmodel).ci(95)
 
 # Extract fitted distance distribution
 Pfit = results.P

--- a/examples/basic/ex_fitting_5pdeer.py
+++ b/examples/basic/ex_fitting_5pdeer.py
@@ -57,7 +57,7 @@ print(results)
 
 # Extract fitted dipolar signal
 Vfit = results.model
-Vci = results.modelUncert.ci(95)
+Vci = results.propagate(Vmodel).ci(95)
 
 # Extract fitted distance distribution
 Pfit = results.P

--- a/examples/basic/ex_fitting_5pdeer_pathways.py
+++ b/examples/basic/ex_fitting_5pdeer_pathways.py
@@ -46,7 +46,7 @@ print(results)
 
 # Extract fitted dipolar signal
 Vfit = results.model
-Vci = results.modelUncert.ci(95)
+Vci = results.propagate(Vmodel).ci(95)
 
 # Extract fitted distance distribution
 Pfit = results.P

--- a/examples/basic/ex_profileanalysis.py
+++ b/examples/basic/ex_profileanalysis.py
@@ -47,7 +47,7 @@ profile_uq = dl.profile_analysis(Vmodel,Vexp,samples=20, parameters=['conc','mod
 #%%
 # Extract fitted dipolar signal
 Vfit = results.model
-Vci = results.modelUncert.ci(95)
+Vci = results.propagate(Vmodel).ci(95)
 
 # Extract fitted distance distribution
 Pfit = results.P

--- a/test/test_snlls.py
+++ b/test/test_snlls.py
@@ -211,7 +211,7 @@ def test_confinter_model():
     ub = 1
     lbl = np.full(len(r), 0)
     # Separable LSQ fit
-    fit = snlls(V,lambda lam: dipolarkernel(t,r,mod=lam),nlpar0,lb,ub,lbl)
+    fit = snlls(V,lambda lam: dipolarkernel(t,r,mod=lam),nlpar0,lb,ub,lbl,modeluq=True)
     Vfit =  fit.model
     Vuq = fit.modelUncert
     Vci50 = Vuq.ci(50)
@@ -699,7 +699,7 @@ def test_complex_model_uncertainty():
     y = y + whitegaussnoise(x,0.01)
     y = y + 1j*whitegaussnoise(x,0.05)
 
-    fitResult = snlls(y,model,par0=[2*np.pi/5,4,0.2],lb=[-np.pi,1,0.05],ub=[np.pi,6,5])
+    fitResult = snlls(y,model,par0=[2*np.pi/5,4,0.2],lb=[-np.pi,1,0.05],ub=[np.pi,6,5],modeluq=True)
     ciwidth = np.sum(fitResult.modelUncert.ci(95)[:,1] - fitResult.modelUncert.ci(95)[:,0])
 
     assert (ciwidth.real < ciwidth.imag).all()

--- a/test/test_snlls_rlls.py
+++ b/test/test_snlls_rlls.py
@@ -138,7 +138,7 @@ def test_confinter_Vfit():
     K = dipolarkernel(t,r,mod=0.2)
     V = K@P + whitegaussnoise(t,0.05)
 
-    fit = snlls(V,K,lbl=np.zeros_like(r))
+    fit = snlls(V,K,lbl=np.zeros_like(r),modeluq=True)
 
     assert_confidence_intervals(fit.modelUncert,fit.model)
 #============================================================


### PR DESCRIPTION
## Features
- Speedup runtime of the `fit` function by disabling the automatic propagation of uncertainty to the model's response. Closes #391 
- Remove the output from the `fit` function returned object.
- Add option `modeluq` to `snlls` to enable /disable the model uncertainty propagation.
- Adapt docs, tests and examples.