### PR TITLE
Remove CVXOPT

### DIFF
--- a/docsrc/source/installation.rst
+++ b/docsrc/source/installation.rst
@@ -39,7 +39,6 @@ DeerLab installs the following packages:
 * `matplotlib <https://matplotlib.org/>`_ - A comprehensive library for creating data visualizations with Python
 * `memoization <https://pypi.org/project/memoization/>`_ - A powerful caching library for Python
 * `pytest <https://docs.pytest.org/en/stable/>`_ - A Python testing framework
-* `cvxopt <https://cvxopt.org/index.html>`_ - Free software package for convex optimization
 * `numpy <https://numpy.org/>`_ -   The fundamental package for scientific computing with Python 
 * `scipy <https://www.scipy.org/>`_ - Fundamental library for scientific computing
 * `joblib <https://joblib.readthedocs.io/en/latest/>`_ - Library lightweight pipelining and parallelization.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     long_description_content_type="text/markdown",
     install_requires = [
                         'numpy>=1.22.4',
-                        'cvxopt>=1.0.0',
                         'scipy>=1.6.3',
                         'joblib>=1.0.0',
                         'dill>=0.3.0',

--- a/test/test_snlls_rlls.py
+++ b/test/test_snlls_rlls.py
@@ -31,7 +31,7 @@ def mock_data(design_matrix, reference):
 
 
 # ============================================================
-@pytest.mark.parametrize('solver',['qp','fnnls','cvx'])
+@pytest.mark.parametrize('solver',['qp','fnnls'])
 def test_RLLS_fit_solvers(mock_data, design_matrix, reference, solver):
     "Check that the RLLS problem is correctly solved by all numerical solvers"
     fit = snlls(mock_data,design_matrix,lbl=lbl,nnlsSolver=solver,uq=False)

--- a/test/test_snlls_rlls.py
+++ b/test/test_snlls_rlls.py
@@ -36,6 +36,14 @@ def test_RLLS_fit_solvers(mock_data, design_matrix, reference, solver):
     "Check that the RLLS problem is correctly solved by all numerical solvers"
     fit = snlls(mock_data,design_matrix,lbl=lbl,nnlsSolver=solver,uq=False)
     assert ovl(reference,fit.param) > 0.95 # more than 95% overlap
+ 
+
+
+def test_RLLS_fit_solvers(mock_data, design_matrix, reference):
+    "Check that the RLLS problem is correctly solved by cvxopt solver"
+    pytest.importorskip("cvxopt")
+    fit = snlls(mock_data,design_matrix,lbl=lbl,nnlsSolver='cvx',uq=False)
+    assert ovl(reference,fit.param) > 0.95 # more than 95% overlap
 # ============================================================
 
 # ============================================================


### PR DESCRIPTION
CVXOPT was removed from being a necessary dependecy in 1.0 but has remained in the `setup.py`. This correct this. 