### PR TITLE
refactor basic sim examples

### DIFF
--- a/examples/basic_simulations/ex_simulate_4pdeer.py
+++ b/examples/basic_simulations/ex_simulate_4pdeer.py
@@ -3,56 +3,57 @@
 Simulating a three-pathway 4-pulse DEER signal
 ============================================================
 
-An example on how to simulate a three-pathway 4-pulse DEER dipolar signal.  
-
-Specifically, we simulate a three-pathway 4-pulse DEER dipolar signal arising from 
-a Gaussian distance distribution.
+An example on how to simulate a 4-pulse DEER dipolar signal,
+including secondary pathways like the "2+1" contribution. This
+example uses a Gaussian distance distibution.
 """
 
 # Import the required libraries
 import numpy as np
 import matplotlib.pyplot as plt
 import deerlab as dl
-violet = '#4550e6'
 
 # %%
 
 # Simulation parameters
-tau1 = 0.5          # First inter-pulse time delay, μs
-tau2 = 4.5          # Second inter-pulse time delay, μs
-conc = 50           # Spin concentration, μs
-lam1 = 0.40         # Amplitude of main contribution 
-lam23 = 0.02        # Ampltiude of the "2+1" contributions
-rmean = 4.0         # Mean distance, nm
-rstd = 0.3          # Distance standard deviation, nm
-Δr = 0.05           # Distance resolution, nm
-rmin,rmax = 1.5,6   # Range of the distance vector, nm 
-Δt = 0.008          # Time resolution, μs 
-deadtime = 0.3      # Acquisition deadtime, μs
+tau1, tau2 = 0.5, 4.5   # Inter-pulse time delays, μs
+tmin = 0.3              # Start time, μs
+Δt = 0.008              # Time increment, μs 
 
-# Experimental time vector
-t = np.arange(deadtime,tau1+tau2,Δt)
+rmean = 4.0             # Mean distance, nm
+rstd = 0.3              # Distance standard deviation, nm
+Δr = 0.05               # Distance increment, nm
+rmin, rmax = 1.5, 6     # Range of the distance vector, nm 
+
+conc = 50               # Spin concentration, μM
+lam1 = 0.40             # Amplitude of main contribution 
+lam23 = 0.02            # Amplitude of the "2+1" contributions
+V0 = 1                  # Overall signal amplitude
+
+# Time vector
+tmax = tau1+tau2
+t = np.arange(tmin, tmax, Δt)
 # Distance vector 
-r = np.arange(rmin,rmax,Δr)
+r = np.arange(rmin, rmax, Δr)
 
 # Experiment model
-experiment = dl.ex_4pdeer(tau1,tau2, pathways=[1,2,3])
-reftime1, reftime2, reftime3 = experiment.reftimes(tau1,tau2)
-
+experiment = dl.ex_4pdeer(tau1, tau2, pathways=[1,2,3])
 
 # Construct the dipolar signal model
-Vmodel = dl.dipolarmodel(t,r,Pmodel=dl.dd_gauss, experiment=experiment) 
-
-# Function for the scaled background
-Vinter_fcn = lambda lam1,lam23,conc: (1-lam1-2*lam23)*dl.bg_hom3d(t-reftime1,conc,lam1)*dl.bg_hom3d(t-reftime2,conc,lam23)*dl.bg_hom3d(t-reftime3,conc,lam23)
+Vmodel = dl.dipolarmodel(t, r, Pmodel=dl.dd_gauss, experiment=experiment) 
 
 # Simulate the signal with orientation selection
-Vsim = Vmodel(mean=rmean, std=rstd, conc=conc, scale=1, lam1=lam1, lam2=lam23, lam3=lam23, reftime1=reftime1, reftime2=reftime2, reftime3=reftime3)
+reftime1, reftime2, reftime3 = experiment.reftimes(tau1, tau2)
+Vsim = Vmodel(mean=rmean, std=rstd, conc=conc, scale=V0, lam1=lam1, lam2=lam23, lam3=lam23, reftime1=reftime1, reftime2=reftime2, reftime3=reftime3)
+
+# Scaled background (for plotting)
+Vinter = V0*(1-lam1-2*lam23)*dl.bg_hom3d(t-reftime1,conc,lam1)*dl.bg_hom3d(t-reftime2,conc,lam23)*dl.bg_hom3d(t-reftime3,conc,lam23)
 
 # Plot the simulated signal
+violet = '#4550e6'
 plt.figure(figsize=[4,3])
-plt.plot(t,Vsim,lw=2,label='V(t)',color=violet)
-plt.plot(t,Vinter_fcn(lam1,lam23,conc),'--',color=violet,lw=2,label='(1-λ)$V_{inter}$')
+plt.plot(t, Vsim, lw=2, label='V(t)', color=violet)
+plt.plot(t, Vinter, '--', color=violet, lw=2, label='(1-λ)$V_{inter}$')
 plt.legend()
 plt.xlabel('Time (μs)')
 plt.ylabel('V(t)')

--- a/examples/basic_simulations/ex_simulate_5pdeer.py
+++ b/examples/basic_simulations/ex_simulate_5pdeer.py
@@ -1,56 +1,57 @@
 # %%
 """
-Simulating a two-pathway 5-pulse DEER signal
+Simulating a 5-pulse DEER signal
 ============================================================
 
-An example on how to simulate a 5-pulse DEER dipolar signal.  
-
-Specifically, we simulate a single-pathway 5-pulse DEER dipolar signal arising from 
-a Gaussian distance distribution
+An example on how to simulate a 5-pulse DEER dipolar signal containing the
+two main dipolar pathway contributions, using a Gaussian distance distribution.
 """
 
 # Import the required libraries
 import numpy as np
 import matplotlib.pyplot as plt
 import deerlab as dl
-violet = '#4550e6'
 
 # %%
 
 # Simulation parameters
-tau1 = 3.5          # 1st experimental time delay, μs
-tau2 = 4.2          # 2nd experimental time delay, μs
-tau3 = 0.3          # 3rd experimental time delay, μs
-conc = 150           # Spin concentration, μM
-lam1 = 0.30         # Amplitude of dipolar pathway refocusing at t=tau3, μs    
-lam2 = 0.15         # Amplitude of dipolar pathway refocusing at t=tau2, μs    
-rmean = 4.0         # Mean distance, nm
-rstd = 0.4          # Distance standard deviation, nm
-rmin,rmax = 1.5,6   # Range of the distance axis, nm
-Δr = 0.05           # Distance resolution, nm
-Δt = 0.008          # Time resolution, μs 
-deadtime = 0.1      # Acquisition deadtime, μs
+tau1, tau2, tau3 = 3.5, 4.2, 0.3  # Inter-pulse delays, μs
+Δt = 0.008              # Time increment, μs 
+tmin = 0.1              # Start time, μs
 
-# Experimental time vector
-t = np.arange(deadtime,tau1+tau2+tau3,Δt)
+rmean = 4.0             # Mean distance, nm
+rstd = 0.4              # Distance standard deviation, nm
+rmin, rmax = 1.5, 6     # Range of the distance axis, nm
+Δr = 0.05               # Distance resolution, nm
+
+conc = 150              # Spin concentration, μM
+lam1 = 0.30             # Amplitude of dipolar pathway refocusing at t=tau3
+lam2 = 0.15             # Amplitude of dipolar pathway refocusing at t=tau2
+V0 = 1                  # Overall echo amplitude
+
+# Time vector
+tmax = tau1+tau2+tau3
+t = np.arange(tmin, tmax, Δt)
 # Distance vector 
-r = np.arange(rmin,rmax,Δr)
+r = np.arange(rmin, rmax, Δr)
 
-experiment = dl.ex_rev5pdeer(tau1,tau2,tau3, pathways=[1,2])
-reftime1, reftime2 = experiment.reftimes(tau1,tau2,tau3)
+experiment = dl.ex_rev5pdeer(tau1, tau2, tau3, pathways=[1,2])
+reftime1, reftime2 = experiment.reftimes(tau1, tau2, tau3)
 
 # Construct the dipolar signal model
-Vmodel = dl.dipolarmodel(t,r,Pmodel=dl.dd_gauss, experiment=experiment) 
-# Function for the scaled background
-Vinter_fcn = lambda lam1,lam2,conc: (1-lam1-lam2)*dl.bg_hom3d(t-reftime1,conc,lam1)*dl.bg_hom3d(t-reftime2,conc,lam2)
+Vmodel = dl.dipolarmodel(t, r, Pmodel=dl.dd_gauss, experiment=experiment) 
 
 # Simulate the signal with orientation selection
-Vsim = Vmodel(mean=rmean, std=rstd, conc=conc, scale=1, lam1=lam1, lam2=lam2, reftime1=reftime1, reftime2=reftime2)
+Vsim = Vmodel(mean=rmean, std=rstd, conc=conc, scale=V0, lam1=lam1, lam2=lam2, reftime1=reftime1, reftime2=reftime2)
+
+# Scaled background (for plotting)
+Vinter = V0*(1-lam1-lam2)*dl.bg_hom3d(t-reftime1,conc,lam1)*dl.bg_hom3d(t-reftime2,conc,lam2)
 
 # Plot the simulated signal
+violet = '#4550e6'
 plt.figure(figsize=[4,3])
-plt.plot(t,Vsim,lw=2,label='V(t)',color=violet)
-plt.plot(t,Vinter_fcn(lam1,lam2,conc),'--',color=violet,lw=2,label='(1-λ)$V_{inter}$')
+plt.plot(t, Vsim, lw=2, label='V(t)', color=violet)
+plt.plot(t, Vinter, '--', color=violet, lw=2, label='(1-λ)$V_{inter}$')
 plt.legend()
 plt.xlabel('Time (μs)')
 plt.ylabel('V(t)')

--- a/examples/basic_simulations/ex_simulate_basic_4pdeer.py
+++ b/examples/basic_simulations/ex_simulate_basic_4pdeer.py
@@ -1,50 +1,55 @@
 # %%
 """
-Simulating a single-pathway 4-pulse DEER signal
+Simulating a 4-pulse DEER signal
 ============================================================
 
-An example on how to simulate a single-pathway 4-pulse DEER dipolar signal.  
-
-Specifically, we simulate a single-pathway 4-pulse DEER dipolar signal arising from 
-a Gaussian distance distribution
+An example on how to simulate a basic 4-pulse DEER dipolar signal, with the main
+dipolar pathway (i.e. without other contributions such as 2+1). This example
+uses a Gaussian distance distribution.
 """
 
 # Import the required libraries
 import numpy as np
 import matplotlib.pyplot as plt
 import deerlab as dl
-violet = '#4550e6'
 
 # %%
 
 # Simulation parameters
-reftime = 0.5       # Refocusing time/Zero-time
-tmax = 3            # Trace length, μs
-mod = 0.40          # Modulation depth
-conc = 50           # Spin concentration, μM
-rmean = 3.0         # Mean distance, nm
-rstd = 0.2          # Distance standard deviation, nm
-Δr = 0.05           # Distance resolution, nm
-rmin,rmax = 1.5,6   # Range of the distance vector, nm 
-Δt = 0.008          # Time resolution, μs 
-deadtime = 0.3      # Acquisition deadtime, μs
-Vamp = 1            # Overall echo amplitude
+tau1, tau2 = 0.5, 2.5 # Inter-pulse delays, µs
+tmin = 0.4            # Start time, μs
+Δt = 0.008            # Time increment, μs 
 
-# Experimental time vector
-t = np.arange(deadtime,tmax,Δt)
+rmean = 3.0           # Mean distance, nm
+rstd = 0.2            # Distance standard deviation, nm
+rmin, rmax = 1.5, 6   # Range of the distance vector, nm 
+Δr = 0.05             # Distance increment, nm
+
+conc = 50             # Spin concentration, μM
+lam = 0.40            # Modulation depth
+V0 = 1                # Overall echo amplitude
+
+# Time vector
+tmax = tau1+tau2
+t = np.arange(tmin, tmax, Δt)
+
 # Distance vector 
-r = np.arange(rmin,rmax,Δr)
+r = np.arange(rmin, rmax, Δr)
 
-# Construct the dipolar signal model
-Vmodel = dl.dipolarmodel(t,r,Pmodel=dl.dd_gauss) 
+# Construct the 4-pulse DEER model
+Vmodel = dl.dipolarmodel(t, r, Pmodel=dl.dd_gauss)
 
 # Simulate the signal with orientation selection
-Vsim = Vmodel(mean=rmean, std=rstd, conc=conc, scale=Vamp, mod=mod, reftime=reftime)
+Vsim = Vmodel(mean=rmean, std=rstd, conc=conc, scale=V0, mod=lam, reftime=tau1)
+
+# Scaled background (for plotting)
+Vinter = V0*(1-lam)*dl.bg_hom3d(t-tau1, conc, lam)
 
 # Plot the simulated signal
+violet = '#4550e6'
 plt.figure(figsize=[4,3])
-plt.plot(t,Vsim, color=violet,lw=2,label='V(t)')
-plt.plot(t,Vamp*(1-mod)*dl.bg_hom3d(t,conc,mod),'--',color=violet,lw=2,label='(1-λ)$V_{inter}$')
+plt.plot(t, Vsim, color=violet, lw=2, label='V(t)')
+plt.plot(t, Vinter, '--', color=violet, lw=2, label='(1-λ)$V_{inter}$')
 plt.legend()
 plt.xlabel('Time (μs)')
 plt.ylabel('V(t)')


### PR DESCRIPTION
- fixes a plotting bug
- makes code more consistent with standard notation from literature
- eliminates "acquisition delay" and "dead time" terminology, use `tmin` instead
- introduces `tau1` and `tau2` in the most basic 4-pulse DEER example
- introduces `V0` (overall amplitude) in all examples
- rearranges code to separate simulation and plotting
- improves compliance with standard whitespace rules
