### PR TITLE
Dipolarkernal speedup

### DIFF
--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -367,7 +367,7 @@ def dipolarkernel(t, r, *, pathways=None, mod=None, bg=None, method='fresnel', e
 
     if tinterp is not None:
         # Construct interpolator, this way elementarykernel_twospin is executed only once independently of how many pathways there are
-        Kinterpolator = [interp1d(tinterp,elementarykernel_twospin(tinterp,r_q,method,excbandwidth,gridsize,g,orisel,complex),axis=0,kind='cubic') for r_q in r]
+        Kinterpolator = _elementarykernel_twospin_interp(tinterp,r,method,excbandwidth,gridsize,g,orisel,complex)
         withinInterpolation = lambda tdip: np.all((np.max(tinterp) >= np.max(tdip)) & (np.min(tinterp) <= np.min(tdip)))
 
     # Define kernel matrix auxiliary functions
@@ -435,8 +435,14 @@ def dipolarkernel(t, r, *, pathways=None, mod=None, bg=None, method='fresnel', e
     
     return K
 #==============================================================================
-
-
+@cached(max_size=100)
+def _elementarykernel_twospin_interp(tinterp,r,method,excbandwidth,gridsize,g,orisel,complex):
+    """
+    Construct interpolator, this way elementarykernel_twospin is executed only once independently of how many pathways there are
+    Cached for performance reasons, interpolation is slow.
+    """
+    Kinterpolator = [interp1d(tinterp,elementarykernel_twospin(tinterp,r_q,method,excbandwidth,gridsize,g,orisel,complex),axis=0,kind='cubic') for r_q in r]
+    return Kinterpolator
 
 #==============================================================================
 #   TWO-SPIN ELEMENTARY DIPOLAR KERNEL

--- a/deerlab/dipolarkernel.py
+++ b/deerlab/dipolarkernel.py
@@ -474,14 +474,15 @@ def elementarykernel_twospin(tdip,r,method,ωex,gridsize,g,Pθ,complex):
     ωr = (μ0/2)*μB**2*g[0]*g[1]/h*1e21/(r**3)  # rad μs^-1
 
     # Orientation selection
-    orientationselection = Pθ is not None 
-    if orientationselection:
-        # Ensure zero-derivatives at [0,π/2]
-        θ = np.linspace(0,π/2,50) # rad
-        Pθ_ = make_interp_spline(θ, Pθ(θ),bc_type="clamped")
-        # Ensure normalization of probability density function (∫P(cosθ)dcosθ=1)
-        Pθnorm,_ = quad(lambda cosθ: Pθ_(np.arccos(cosθ)),0,1,limit=1000)
-        Pθ = lambda θ: Pθ_(θ)/Pθnorm
+    if method != 'fresnel':
+        orientationselection = Pθ is not None 
+        if orientationselection:
+            # Ensure zero-derivatives at [0,π/2]
+            θ = np.linspace(0,π/2,50) # rad
+            Pθ_ = make_interp_spline(θ, Pθ(θ),bc_type="clamped")
+            # Ensure normalization of probability density function (∫P(cosθ)dcosθ=1)
+            Pθnorm,_ = quad(lambda cosθ: Pθ_(np.arccos(cosθ)),0,1,limit=1000)
+            Pθ = lambda θ: Pθ_(θ)/Pθnorm
 
     def elementarykernel_fresnel(tdip):
     #------------------------------------------------------------------------

--- a/docsrc/source/changelog.rst
+++ b/docsrc/source/changelog.rst
@@ -27,6 +27,7 @@ Release Notes
 Release ``v1.1.3`` - Ongoing
 ------------------------------------------
 - |fix| : Removes unnecessary files from the docs
+- |efficiency| : Improves the performance of the ``dipolarkernel`` function by 10-30% (:pr:`473`), by caching the interpolation of he effective dipolar evolution time vector.
 
 Release ``v1.1.2`` - November 2023
 ------------------------------------------


### PR DESCRIPTION
A significant speed up of the dipolar kernal

Currently the effective dipolar evolution time vector is interpolated on every run of dipolar kernal even though it never changes. Interpolation should be avoid as much as possible as it is very slow in Python. This interpolation is now cached so it only done once per pathway. 

Speedup:
(Using CVXOPT nnlssolver) 9.0s -> 7.9s 10% faster
(Using quadprog nnlssolver) 2.8s -> 2.2s 20 % faster


CProfile (using quadprog):
Before:
```
   471585 function calls (454090 primitive calls) in 2.776 seconds

   Ordered by: internal time
   List reduced from 765 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       60    0.584    0.010    0.585    0.010 linalg.py:1499(svd)
      101    0.549    0.005    0.550    0.005 linalg.py:492(inv)
      115    0.413    0.004    0.447    0.004 _bsplines.py:1138(make_interp_spline)
      101    0.207    0.002    0.929    0.009 selregparam.py:190(_evalalpha)
      157    0.153    0.001    0.164    0.001 solvers.py:1104(qpnnls)
      115    0.119    0.001    0.981    0.009 dipolarmodel.py:427(Vtwospin_nonlinear_fcn)
      157    0.095    0.001    0.096    0.001 solvers.py:88(_lsqcomponents)
      230    0.056    0.000    0.056    0.000 _bsplines.py:511(_evaluate)
       56    0.032    0.001    1.593    0.028 solvers.py:581(linear_problem)
      115    0.029    0.000    0.855    0.007 dipolarkernel.py:22(dipolarkernel)

```
After:
```
      450059 function calls (432453 primitive calls) in 2.194 seconds

   Ordered by: internal time
   List reduced from 766 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      101    0.704    0.007    0.705    0.007 linalg.py:492(inv)
       60    0.424    0.007    0.425    0.007 linalg.py:1499(svd)
      101    0.199    0.002    1.088    0.011 selregparam.py:190(_evalalpha)
      157    0.149    0.001    0.158    0.001 solvers.py:1104(qpnnls)
      157    0.108    0.001    0.108    0.001 solvers.py:88(_lsqcomponents)
      115    0.063    0.001    0.409    0.004 dipolarmodel.py:427(Vtwospin_nonlinear_fcn)
      230    0.035    0.000    0.035    0.000 _bsplines.py:511(_evaluate)
       56    0.029    0.001    1.613    0.029 solvers.py:581(linear_problem)
      115    0.026    0.000    0.339    0.003 dipolarkernel.py:22(dipolarkernel)
12876/348    0.024    0.000    0.078    0.000 arrayprint.py:789(recurser)

```