### PR TITLE
Adding support for scipy 1.14 and tests for Python 3.12

### DIFF
--- a/.github/workflows/ci_PR.yml
+++ b/.github/workflows/ci_PR.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10','3.11']
+        python-version: ['3.11','3.12']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci_scheduled.yml
+++ b/.github/workflows/ci_scheduled.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12","3.12"]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/package_upload.yml
+++ b/.github/workflows/package_upload.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v1
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v1
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install pypa/build
       run: >-
         python -m pip install build --user

--- a/deerlab/diststats.py
+++ b/deerlab/diststats.py
@@ -7,7 +7,7 @@ import numpy as np
 import warnings
 import copy
 from scipy.signal import find_peaks
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid as cumtrapz
 
 def diststats(r, P, Puq=None, verbose=False, threshold=None):
     r""" 

--- a/docsrc/source/changelog.rst
+++ b/docsrc/source/changelog.rst
@@ -28,6 +28,7 @@ Release ``v1.1.3`` - Ongoing
 ------------------------------------------
 - |fix| : Removes unnecessary files from the docs
 - |efficiency| : Improves the performance of the ``dipolarkernel`` function by 10-30% (:pr:`473`), by caching the interpolation of he effective dipolar evolution time vector.
+- |fix| : add support for Python 3.12
 
 Release ``v1.1.2`` - November 2023
 ------------------------------------------


### PR DESCRIPTION
Adding testing for python 3.12

In the latest scipy versions `cumtrapz` is renamed to `cumulative_trapezoid` in scipy `1.6.0` and cumtrapz was removed in `1.14`