### PR TITLE
Fix issue with frozen Pmodels not being preserved by dipolarmodel.py and dd_* and bg_* imports are now copies

### DIFF
--- a/deerlab/__init__.py
+++ b/deerlab/__init__.py
@@ -1,6 +1,16 @@
 # __init__.py
-from .dd_models import *
-from .bg_models import *
+from . import dd_models as _dd_models_mod
+from . import bg_models as _bg_models_mod
+
+# Define __getattr__ early so submodules that do `from deerlab import bg_*`
+# during their own import (e.g. dipolarmodel) can resolve names via this hook.
+def __getattr__(name):
+    if name in _dd_models_mod.__all__:
+        return _dd_models_mod.__getattr__(name)
+    if name in _bg_models_mod.__all__:
+        return _bg_models_mod.__getattr__(name)
+    raise AttributeError(f"module 'deerlab' has no attribute {name!r}")
+
 from .model import Model, Penalty, Parameter, link, lincombine, merge, relate
 from .deerload import deerload
 from .selregparam import selregparam

--- a/deerlab/bg_models.py
+++ b/deerlab/bg_models.py
@@ -7,6 +7,7 @@ import numpy as np
 import math as m
 from numpy import pi
 import inspect
+from copy import deepcopy as _deepcopy
 from deerlab.dipolarkernel import dipolarkernel
 from deerlab.utils import formatted_table
 from deerlab.model import Model
@@ -513,3 +514,19 @@ bg_poly3.p2.set(description='2nd order weight', lb=-200, ub=200, par0=-1, unit=r
 bg_poly3.p3.set(description='3rd order weight', lb=-200, ub=200, par0=-1, unit=r'μs\ :sup:`-3`')
 # Add documentation
 bg_poly3.__doc__ = _docstring(bg_poly3,notes)
+
+
+# ---------------------------------------------------------------------------
+# Return a fresh deepcopy on every attribute access so that modifications
+# to a retrieved model never affect the global template.
+# ---------------------------------------------------------------------------
+_templates = {name: obj for name, obj in list(globals().items()) if name.startswith('bg_')}
+for _name in list(_templates):
+    del globals()[_name]
+
+__all__ = list(_templates.keys())
+
+def __getattr__(name):
+    if name in _templates:
+        return _deepcopy(_templates[name])
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/deerlab/dd_models.py
+++ b/deerlab/dd_models.py
@@ -7,6 +7,7 @@
 import inspect
 import numpy as np
 import scipy.special as spc
+from copy import deepcopy as _deepcopy
 from deerlab.model import Model
 from deerlab.utils import formatted_table
 
@@ -1042,3 +1043,19 @@ dd_wormgauss.persistence.set(description='Persistence length', lb=2, ub=100, par
 dd_wormgauss.std.set(description='Gaussian standard deviation', lb=0.01, ub=5, par0=0.2, unit='nm')
 # Add documentation
 dd_wormgauss.__doc__ = _dd_docstring(dd_wormgauss,notes) +  docstr_example('dd_wormgauss')
+
+
+# ---------------------------------------------------------------------------
+# Return a fresh deepcopy on every attribute access so that modifications
+# to a retrieved model never affect the global template.
+# ---------------------------------------------------------------------------
+_templates = {name: obj for name, obj in list(globals().items()) if name.startswith('dd_')}
+for _name in list(_templates):
+    del globals()[_name]
+
+__all__ = list(_templates.keys())
+
+def __getattr__(name):
+    if name in _templates:
+        return _deepcopy(_templates[name])
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/deerlab/dipolarmodel.py
+++ b/deerlab/dipolarmodel.py
@@ -157,7 +157,9 @@ def dipolarmodel(t, r=None, Pmodel=None, Bmodel=bg_hom3d, experiment=None, param
             'par0' : parameter.par0,
             'description' : parameter.description,
             'unit' : parameter.unit,
-            'linear' : parameter.linear
+            'linear' : parameter.linear,
+            'frozen' : parameter.frozen,
+            'value' : parameter.value
         }
     #------------------------------------------------------------------------
 

--- a/test/test_ddmodels.py
+++ b/test/test_ddmodels.py
@@ -105,3 +105,16 @@ def test_dd_wormchain():
 
 def test_dd_wormgauss():
     assert_ddmodel(dl.dd_wormgauss)
+
+
+def test_freezing_model():
+    "Check that freezing parameters of a model works as expected"
+
+    # Create model and freeze parameters
+    model = dl.dd_gauss
+    model.mean.freeze(3)
+    model.std.freeze(0.2)
+
+    # Check that the frozen parameters are correctly set
+    assert model.mean.frozen and model.mean.value == 3
+    assert model.std.frozen and model.std.value == 0.2

--- a/test/test_ddmodels.py
+++ b/test/test_ddmodels.py
@@ -111,7 +111,7 @@ def test_freezing_model():
     "Check that freezing parameters of a model works as expected"
 
     # Create model and freeze parameters
-    model = dl.dd_gauss
+    model = dl.dd_gauss.copy()
     model.mean.freeze(3)
     model.std.freeze(0.2)
 

--- a/test/test_dipolarmodel.py
+++ b/test/test_dipolarmodel.py
@@ -241,6 +241,21 @@ def test_fit_3pathways(V3path):
     assert np.allclose(result.model,V3path)
 # ======================================================================
 
+# ======================================================================
+def test_freeze_fit_linear(V1path): 
+    "Check that the model can be correctly fitted with a frozen linear parameter"
+    
+    dd_model = dd_gauss
+    dd_model.std.freeze(0.25)
+
+    assert dd_model.std.frozen and dd_model.std.value == 0.25
+    Vmodel = dipolarmodel(t,r,dd_gauss,bg_hom3d,npathways=1)
+    assert Vmodel.std.frozen and Vmodel.std.value == 0.25
+    
+    result = fit(Vmodel,V1path,ftol=1e-4)
+
+    assert np.allclose(result.std,0.25)
+# ======================================================================
 # Fixtures
 # ----------------------------------------------------------------------
 @fixture(scope='module')

--- a/test/test_model_penalty.py
+++ b/test/test_model_penalty.py
@@ -66,6 +66,7 @@ def test_weight_freeze(penalty_fcn):
     penaltyobj = Penalty(penalty_fcn,'icc')
     penaltyobj.weight.freeze(0.5)
     assert penaltyobj.weight.frozen==True and penaltyobj.weight.value==0.5
+    penaltyobj.weight.unfreeze()
 # ======================================================================
 
 # ======================================================================
@@ -74,6 +75,7 @@ def test_fit(penalty_fcn, model, mock_data, selection):
     "Check fitting with a penalty with ICC-selected weight"
     penaltyobj = Penalty(penalty_fcn, selection)
     penaltyobj.weight.set(lb=1e-6,ub=1e1)
+    assert not penaltyobj.weight.frozen
     result = fit(model,mock_data,x,penalties=penaltyobj)
     assert ovl(result.model,mock_data)>0.975
 # ======================================================================
@@ -89,6 +91,7 @@ def test_fit_with_penalty_weight(penalty_fcn, model, mock_data, case):
         penaltyobj.weight.freeze(0.00001)
     result = fit(model,mock_data,x,penalties=penaltyobj)
     assert ovl(result.model,mock_data)>0.975
+    penaltyobj.weight.unfreeze()
 # ======================================================================
 
 # ======================================================================


### PR DESCRIPTION
It was reported in #499 that, there seemed to be a bug that when a Pmodel with a frozen parameter is passed to dipolarmodel it is forgotten. However, by fixing this issue we cause problems as the base dd_* (bg_*) models are globals so the freezing the PModel affects the global not the local instance. In my opinion this is bad implementation.

To resolve this further problem I have modified how dd_* and bg_* models are imported so they now import as copies of the global. Resolving this issue, with no wider effects. 

Closes #499 