### PR TITLE
Fix SyntaxWarning: invalid escape sequence '\m' in fitresult.py

### DIFF
--- a/deerlab/fitresult.py
+++ b/deerlab/fitresult.py
@@ -367,7 +367,7 @@ class FitResult(dict):
                         bins = np.linspace(-4,4,300)
                         N0 = dd_gauss(bins,0,1)
                         axs[n].get_yaxis().set_visible(False)
-                        axs[n].fill(bins,N0,'k',alpha=0.4, label='$\mathcal{N}(0,1)$')
+                        axs[n].fill(bins,N0,'k',alpha=0.4, label=r'$\mathcal{N}(0,1)$')
                         axs[n].set_xlabel('Normalized residuals',size=fontsize)       
                         axs[n].set_yticks([])
                         axs[n].spines.right.set_visible(False)


### PR DESCRIPTION
Fixes #507.

Adds `r` prefix to the LaTeX label string at `deerlab/fitresult.py:370` so Python 3.12+ no longer emits `SyntaxWarning: invalid escape sequence '\m'` when importing the module.

The actual string content is unchanged (`\m` was already being treated as literal backslash + 'm'); only the string literal syntax becomes warning-free.